### PR TITLE
feat: layered deterministic router with ambiguous task corpus

### DIFF
--- a/tcp/agent/__init__.py
+++ b/tcp/agent/__init__.py
@@ -11,6 +11,7 @@ from tcp.agent.benchmark import (
     SmokeResult,
     build_filtered_schemas,
     build_fixed_filtered_schemas,
+    run_layered_benchmark,
     run_paired_benchmark,
     run_smoke_test,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "build_agent_tasks",
     "get_mock_executor",
     "run_agent_loop",
+    "run_layered_benchmark",
     "run_paired_benchmark",
     "run_preflight",
     "run_smoke_test",

--- a/tcp/agent/ambiguous_tasks.py
+++ b/tcp/agent/ambiguous_tasks.py
@@ -46,7 +46,7 @@ def _tool(
         commands=frozenset(),
         input_formats=input_formats or frozenset(),
         output_formats=output_formats or frozenset(),
-        permission_level="standard",
+        permission_level="unknown",
         avg_processing_time_ms=10.0,
         memory_usage_mb=64.0,
         rich_metadata={"description": description},

--- a/tcp/agent/ambiguous_tasks.py
+++ b/tcp/agent/ambiguous_tasks.py
@@ -1,0 +1,326 @@
+"""Ambiguous task corpus for the TCP layered deterministic router.
+
+Each task has 2-5 viable synthetic tools that all pass the same gating
+filters, requiring the LLM to make the final selection based on prompt
+context and tool descriptions.
+
+Unlike the deterministic tasks in tasks.py (where filters narrow to 1 tool),
+ambiguous tasks intentionally leave multiple survivors so the router's LLM
+selection layer is exercised.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tcp.agent.tasks import AgentTask
+from tcp.core.descriptors import CapabilityFlags
+from tcp.harness.models import ToolRecord, ToolSelectionRequest
+
+
+@dataclass(frozen=True)
+class AmbiguousTask:
+    """A task with multiple viable tools requiring LLM disambiguation."""
+
+    agent_task: AgentTask
+    selection_request: ToolSelectionRequest
+    ambiguity_reason: str
+    synthetic_tools: tuple[ToolRecord, ...] = field(default_factory=tuple)
+
+
+def _tool(
+    name: str,
+    description: str,
+    capability_flags: int,
+    risk_level: str = "safe",
+    input_formats: frozenset[str] | None = None,
+    output_formats: frozenset[str] | None = None,
+) -> ToolRecord:
+    """Convenience constructor for synthetic ToolRecord instances."""
+    return ToolRecord(
+        tool_name=name,
+        descriptor_source="synthetic",
+        descriptor_version="1.0",
+        capability_flags=capability_flags,
+        risk_level=risk_level,
+        commands=frozenset(),
+        input_formats=input_formats or frozenset(),
+        output_formats=output_formats or frozenset(),
+        permission_level="standard",
+        avg_processing_time_ms=10.0,
+        memory_usage_mb=64.0,
+        rich_metadata={"description": description},
+    )
+
+
+def build_ambiguous_tasks() -> list[AmbiguousTask]:
+    """Build the 6 ambiguous tasks for LLM selection validation."""
+    _files_flag = int(CapabilityFlags.SUPPORTS_FILES)
+    _net_flag = int(CapabilityFlags.SUPPORTS_NETWORK)
+
+    return [
+        # --- Task 1: Pattern search across files ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="pattern search",
+                prompt=(
+                    "Search for the pattern 'TODO fix auth' across all Python "
+                    "source files in the current directory. Use grep."
+                ),
+                expected_tool="grep",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=_files_flag,
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "grep, ripgrep, and fs-search-files all support file access; "
+                "prompt explicitly names grep"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "grep",
+                    "POSIX grep — search for patterns in files using regular expressions.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"text"}),
+                ),
+                _tool(
+                    "ripgrep",
+                    "ripgrep (rg) — fast regex search optimised for large codebases.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"json", "text"}),
+                ),
+                _tool(
+                    "fs-search-files",
+                    "MCP filesystem tool — search files by name or content glob.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"json"}),
+                ),
+            ),
+        ),
+
+        # --- Task 2: Fetch remote data ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="fetch remote data",
+                prompt=(
+                    "Fetch the deployment status from "
+                    "https://api.example.com/deploy and return the result as JSON. "
+                    "Use http-fetch for structured JSON responses."
+                ),
+                expected_tool="http-fetch",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=_net_flag,
+                required_output_formats={"json"},
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "curl, http-fetch, and wget all have SUPPORTS_NETWORK and json output; "
+                "prompt names http-fetch for structured JSON"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "curl",
+                    "curl — transfers data from/to servers using HTTP, FTP, and more.",
+                    _net_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"json", "text", "binary"}),
+                ),
+                _tool(
+                    "http-fetch",
+                    "http-fetch — structured HTTP client returning parsed JSON responses.",
+                    _net_flag,
+                    input_formats=frozenset({"json"}),
+                    output_formats=frozenset({"json"}),
+                ),
+                _tool(
+                    "wget",
+                    "wget — non-interactive network downloader supporting HTTP/HTTPS/FTP.",
+                    _net_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"json", "text", "binary"}),
+                ),
+            ),
+        ),
+
+        # --- Task 3: Transform JSON ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="json transform",
+                prompt=(
+                    "Extract the 'users[].email' field from the JSON file "
+                    "/tmp/report.json. jq is the preferred tool for JSON transformations."
+                ),
+                expected_tool="jq",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=_files_flag,
+                required_input_formats={"json"},
+                required_output_formats={"json"},
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "jq, python-exec, and node-exec all accept json input, emit json output, "
+                "and support files; prompt names jq"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "jq",
+                    "jq — lightweight command-line JSON processor with its own query language.",
+                    _files_flag,
+                    input_formats=frozenset({"json"}),
+                    output_formats=frozenset({"json", "text"}),
+                ),
+                _tool(
+                    "python-exec",
+                    "python-exec — run Python snippets; can parse and emit JSON.",
+                    _files_flag,
+                    input_formats=frozenset({"json", "text"}),
+                    output_formats=frozenset({"json", "text"}),
+                ),
+                _tool(
+                    "node-exec",
+                    "node-exec — run Node.js snippets; has native JSON support.",
+                    _files_flag,
+                    input_formats=frozenset({"json", "text"}),
+                    output_formats=frozenset({"json", "text"}),
+                ),
+            ),
+        ),
+
+        # --- Task 4: Write config file ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="write config file",
+                prompt=(
+                    "Write the following YAML content to /etc/myapp/config.yaml. "
+                    "Use fs-write-file to create or overwrite a file directly."
+                ),
+                expected_tool="fs-write-file",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=_files_flag,
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "fs-write-file, tee, and editor all support file access; "
+                "prompt names fs-write-file for direct file creation"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "fs-write-file",
+                    "fs-write-file — MCP filesystem tool to write or overwrite a file.",
+                    _files_flag,
+                    input_formats=frozenset({"text", "json"}),
+                    output_formats=frozenset({"json"}),
+                ),
+                _tool(
+                    "tee",
+                    "tee — reads from stdin and writes to both stdout and one or more files.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"text"}),
+                ),
+                _tool(
+                    "editor",
+                    "editor — opens a file in the system's default text editor.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"json", "text"}),
+                ),
+            ),
+        ),
+
+        # --- Task 5: Check service status ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="check service status",
+                prompt=(
+                    "Check whether the postgres service is running. "
+                    "Use systemctl for systemd-managed services."
+                ),
+                expected_tool="systemctl",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=0,
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "systemctl, ps, and pgrep all have no required flags and pass all filters; "
+                "prompt names systemctl for systemd service management"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "systemctl",
+                    "systemctl — control the systemd system and service manager.",
+                    0,
+                    risk_level="safe",
+                ),
+                _tool(
+                    "ps",
+                    "ps — report a snapshot of current processes.",
+                    0,
+                    risk_level="safe",
+                ),
+                _tool(
+                    "pgrep",
+                    "pgrep — look up processes by name and signal them.",
+                    0,
+                    risk_level="safe",
+                ),
+            ),
+        ),
+
+        # --- Task 6: Diff two files ---
+        AmbiguousTask(
+            agent_task=AgentTask(
+                name="diff files",
+                prompt=(
+                    "Show the differences between /tmp/config_v1.yaml and "
+                    "/tmp/config_v2.yaml. Use diff for a standard unified diff."
+                ),
+                expected_tool="diff",
+            ),
+            selection_request=ToolSelectionRequest.from_kwargs(
+                required_capability_flags=_files_flag,
+                preferred_criteria="speed",
+                require_auto_approval=False,
+            ),
+            ambiguity_reason=(
+                "diff, git-diff, and colordiff all support file access; "
+                "prompt names diff for standard unified diff output"
+            ),
+            synthetic_tools=(
+                _tool(
+                    "diff",
+                    "diff — compare files line by line and output a unified diff.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"text"}),
+                ),
+                _tool(
+                    "git-diff",
+                    "git-diff — show changes between git commits, working tree, etc.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"text", "json"}),
+                ),
+                _tool(
+                    "colordiff",
+                    "colordiff — wrapper around diff producing coloured output.",
+                    _files_flag,
+                    input_formats=frozenset({"text"}),
+                    output_formats=frozenset({"text"}),
+                ),
+            ),
+        ),
+    ]

--- a/tcp/agent/benchmark.py
+++ b/tcp/agent/benchmark.py
@@ -9,13 +9,17 @@ from __future__ import annotations
 import json
 import os
 import random
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Callable
 
+from tcp.agent.ambiguous_tasks import build_ambiguous_tasks
+from tcp.agent.lane_report import LaneReport, build_lane_report
 from tcp.agent.loop import LoopMetrics, run_agent_loop
 from tcp.agent.mock_executors import get_mock_executor
+from tcp.agent.routing_strategy import should_bypass_llm
 from tcp.agent.tasks import AgentTask, build_agent_tasks
+from tcp.harness.router import RouteConfidence, RouteResult
 
 
 @dataclass(frozen=True)
@@ -573,3 +577,122 @@ async def run_adversarial_ablation(
                 os.replace(tmp, results_path)
 
     return AblationReport(trials=tuple(all_trials))
+
+
+async def run_layered_benchmark(
+    *,
+    repetitions: int = 3,
+    model: str = "claude-sonnet-4-6",
+    results_path: Path | None = None,
+) -> LaneReport:
+    """Run the layered benchmark: deterministic bypass + ambiguous LLM path.
+
+    1. Builds combined task set (12 deterministic + 6 ambiguous + 3 no-match)
+    2. For each task, runs per-task filtering and classifies confidence
+    3. DETERMINISTIC: bypass LLM, invoke executor directly
+    4. AMBIGUOUS/NO_MATCH: send filtered tools to LLM
+    5. Returns three-lane report
+    """
+    from tcp.harness.corpus import build_mcp_corpus
+    from tcp.harness.gating import RuntimeEnvironment, gate_tools
+    from tcp.harness.models import ToolSelectionRequest
+    from tcp.harness.normalize import normalize_capability_descriptor
+    from tcp.harness.schema_bridge import corpus_to_anthropic_schemas
+
+    # Build tasks
+    det_tasks = build_agent_tasks()
+    amb_tasks_raw = build_ambiguous_tasks()
+    amb_tasks = [
+        AgentTask(
+            name=at.agent_task.name,
+            prompt=at.agent_task.prompt,
+            expected_tool=at.agent_task.expected_tool,
+            selection_request=at.selection_request,
+        )
+        for at in amb_tasks_raw
+    ]
+    all_tasks = det_tasks + amb_tasks
+
+    # Build corpus (include synthetic tools from ambiguous tasks)
+    entries = build_mcp_corpus()
+    corpus_schemas = corpus_to_anthropic_schemas(entries)
+    records = [normalize_capability_descriptor(e.descriptor) for e in entries]
+
+    # Add synthetic tool records and schemas
+    for at in amb_tasks_raw:
+        for tool in at.synthetic_tools:
+            records.append(tool)
+            corpus_schemas.append({
+                "name": tool.tool_name,
+                "description": f"Synthetic tool: {tool.tool_name}",
+                "input_schema": {"type": "object", "properties": {}},
+            })
+
+    schema_by_name = {s["name"]: s for s in corpus_schemas}
+    all_names = frozenset(r.tool_name for r in records)
+    env = RuntimeEnvironment(
+        network_enabled=False,
+        file_access_enabled=True,
+        stdin_enabled=True,
+        installed_tools=all_names,
+    )
+    default_request = ToolSelectionRequest.from_kwargs(
+        preferred_criteria="speed",
+        require_auto_approval=False,
+    )
+
+    mock_exec = get_mock_executor()
+    all_metrics: list[LoopMetrics] = []
+
+    for task in all_tasks:
+        request = task.selection_request or default_request
+        gate_result = gate_tools(records, request, env)
+        survivor_names = {t.tool_name for t in gate_result.approved_tools}
+        survivor_names |= {t.tool_name for t in gate_result.approval_required_tools}
+        filtered_schemas = [schema_by_name[n] for n in survivor_names if n in schema_by_name]
+
+        survivor_count = len(survivor_names)
+        if survivor_count == 0:
+            confidence = RouteConfidence.NO_MATCH
+        elif survivor_count == 1:
+            confidence = RouteConfidence.DETERMINISTIC
+        else:
+            confidence = RouteConfidence.AMBIGUOUS
+
+        route_result = RouteResult(
+            selected_tool=None,
+            confidence=confidence,
+            survivor_count=survivor_count,
+        )
+
+        for _rep in range(repetitions):
+            if should_bypass_llm(route_result):
+                bypass_name = next(iter(survivor_names))
+                metrics = await run_agent_loop(
+                    task_prompt=task.prompt,
+                    tools=filtered_schemas,
+                    mock_executor=mock_exec,
+                    expected_tool=task.expected_tool,
+                    task_name=task.name,
+                    model=model,
+                    bypass_tool=bypass_name,
+                )
+            else:
+                metrics = await run_agent_loop(
+                    task_prompt=task.prompt,
+                    tools=filtered_schemas,
+                    mock_executor=mock_exec,
+                    expected_tool=task.expected_tool,
+                    task_name=task.name,
+                    model=model,
+                )
+
+            # Patch routing metadata onto metrics
+            metrics = replace(
+                metrics,
+                route_confidence=confidence.value,
+                survivor_count=survivor_count,
+            )
+            all_metrics.append(metrics)
+
+    return build_lane_report(all_metrics)

--- a/tcp/agent/benchmark.py
+++ b/tcp/agent/benchmark.py
@@ -176,6 +176,9 @@ def _metrics_to_dict(m: LoopMetrics) -> dict:
         "selected_tool_correct": m.selected_tool_correct,
         "error": m.error,
         "error_kind": m.error_kind,
+        "llm_bypassed": m.llm_bypassed,
+        "route_confidence": m.route_confidence,
+        "survivor_count": m.survivor_count,
     }
 
 

--- a/tcp/agent/cli.py
+++ b/tcp/agent/cli.py
@@ -53,6 +53,11 @@ def main() -> None:
         action="store_true",
         help="Run scale stress test with 500+ tool corpus",
     )
+    mode.add_argument(
+        "--layered",
+        action="store_true",
+        help="Run layered benchmark (deterministic bypass + ambiguous LLM)",
+    )
     parser.add_argument(
         "--reps",
         type=int,
@@ -94,6 +99,10 @@ def main() -> None:
         if not _cmd_preflight():
             sys.exit(1)
         asyncio.run(_cmd_scale(args.reps, args.model, args.output))
+    elif args.layered:
+        if not _cmd_preflight():
+            sys.exit(1)
+        asyncio.run(_cmd_layered(args.reps, args.model, args.output))
 
 
 def _cmd_preflight() -> bool:
@@ -305,3 +314,24 @@ async def _cmd_scale(reps: int, model: str, output: Path | None) -> None:
             for arm, m in [("F", t.filtered), ("U", t.unfiltered)]:
                 if m.error:
                     print(f"  [{arm}] {t.task_name}: [{m.error_kind}] {m.error[:80]}")
+
+
+async def _cmd_layered(reps: int, model: str, output: Path | None) -> None:
+    """Run the layered benchmark."""
+    from tcp.agent.benchmark import run_layered_benchmark
+
+    print(
+        f"\n--- Layered benchmark ---"
+        f"\n  Reps: {reps}"
+        f"\n  Model: {model}"
+    )
+    if output:
+        print(f"  Results: {output}")
+
+    report = await run_layered_benchmark(
+        repetitions=reps,
+        model=model,
+        results_path=output,
+    )
+
+    print(f"\n{report.summary_table()}")

--- a/tcp/agent/lane_report.py
+++ b/tcp/agent/lane_report.py
@@ -1,0 +1,91 @@
+"""Three-lane benchmark reporting for the layered deterministic router.
+
+Splits trial metrics into deterministic / ambiguous / no-match lanes
+and computes per-lane statistics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tcp.agent.loop import LoopMetrics
+
+
+@dataclass(frozen=True)
+class LaneReport:
+    """Per-lane summary statistics."""
+
+    deterministic_count: int
+    deterministic_correct_rate: float
+    deterministic_mean_latency_ms: float
+
+    ambiguous_count: int
+    ambiguous_correct_rate: float
+    ambiguous_mean_latency_ms: float
+    ambiguous_mean_tokens: float
+
+    no_match_count: int
+    no_match_correct_rate: float
+
+    bypass_ratio: float
+    ambiguous_llm_lift: float
+
+    def summary_table(self) -> str:
+        lines = [
+            f"{'Lane':<20} {'Count':>6} {'Correct':>8} {'Latency':>10} {'Tokens':>8}",
+            "-" * 55,
+            f"{'Deterministic':<20} {self.deterministic_count:>6} "
+            f"{self.deterministic_correct_rate:>7.0%} "
+            f"{self.deterministic_mean_latency_ms:>9.0f}ms {'—':>8}",
+            f"{'Ambiguous':<20} {self.ambiguous_count:>6} "
+            f"{self.ambiguous_correct_rate:>7.0%} "
+            f"{self.ambiguous_mean_latency_ms:>9.0f}ms "
+            f"{self.ambiguous_mean_tokens:>8.0f}",
+            f"{'No-match':<20} {self.no_match_count:>6} "
+            f"{self.no_match_correct_rate:>7.0%} {'—':>10} {'—':>8}",
+            "-" * 55,
+            f"Bypass ratio: {self.bypass_ratio:.0%}",
+            f"Ambiguous LLM lift: {self.ambiguous_llm_lift:+.0%}",
+        ]
+        return "\n".join(lines)
+
+
+def build_lane_report(
+    metrics: list[LoopMetrics],
+    *,
+    select_best_correct_rate: float = 0.0,
+) -> LaneReport:
+    """Build a three-lane report from a flat list of LoopMetrics."""
+    det = [m for m in metrics if m.route_confidence == "deterministic"]
+    amb = [m for m in metrics if m.route_confidence == "ambiguous"]
+    nm = [m for m in metrics if m.route_confidence == "no_match"]
+
+    det_n = len(det)
+    amb_n = len(amb)
+    nm_n = len(nm)
+    total = len(metrics)
+
+    det_correct = sum(1 for m in det if m.selected_tool_correct) / det_n if det_n else 0.0
+    amb_correct = sum(1 for m in amb if m.selected_tool_correct) / amb_n if amb_n else 0.0
+    nm_correct = sum(1 for m in nm if m.selected_tool_correct) / nm_n if nm_n else 0.0
+
+    det_latency = sum(m.total_response_time_ms for m in det) / det_n if det_n else 0.0
+    amb_latency = sum(m.total_response_time_ms for m in amb) / amb_n if amb_n else 0.0
+    amb_tokens = sum(m.input_tokens for m in amb) / amb_n if amb_n else 0.0
+
+    bypass = sum(1 for m in metrics if m.llm_bypassed) / total if total else 0.0
+    lift = amb_correct - select_best_correct_rate
+
+    return LaneReport(
+        deterministic_count=det_n,
+        deterministic_correct_rate=det_correct,
+        deterministic_mean_latency_ms=det_latency,
+        ambiguous_count=amb_n,
+        ambiguous_correct_rate=amb_correct,
+        ambiguous_mean_latency_ms=amb_latency,
+        ambiguous_mean_tokens=amb_tokens,
+        no_match_count=nm_n,
+        no_match_correct_rate=nm_correct,
+        bypass_ratio=bypass,
+        ambiguous_llm_lift=lift,
+    )

--- a/tcp/agent/loop.py
+++ b/tcp/agent/loop.py
@@ -43,6 +43,8 @@ class LoopMetrics:
     error: str | None
     error_kind: str | None = None
     llm_bypassed: bool = False
+    route_confidence: str = ""
+    survivor_count: int = 0
 
 
 async def run_agent_loop(

--- a/tcp/agent/loop.py
+++ b/tcp/agent/loop.py
@@ -42,6 +42,7 @@ class LoopMetrics:
     selected_tool_correct: bool
     error: str | None
     error_kind: str | None = None
+    llm_bypassed: bool = False
 
 
 async def run_agent_loop(
@@ -53,6 +54,7 @@ async def run_agent_loop(
     task_name: str,
     model: str = "claude-sonnet-4-6",
     max_turns: int = 5,
+    bypass_tool: str | None = None,
 ) -> LoopMetrics:
     """Execute a single agent loop and return metrics.
 
@@ -61,6 +63,26 @@ async def run_agent_loop(
     3. Feed tool_result back, repeat until text-only or max_turns
     4. Collect timing at every API call boundary
     """
+    # --- Deterministic bypass path ---
+    if bypass_tool is not None:
+        total_start = time.perf_counter_ns()
+        mock_executor(bypass_tool, {})
+        total_end = time.perf_counter_ns()
+        correct = bypass_tool == expected_tool
+        return LoopMetrics(
+            task_name=task_name,
+            tool_count=len(tools),
+            turns=0,
+            first_token_latency_ms=0.0,
+            total_response_time_ms=(total_end - total_start) / 1_000_000,
+            input_tokens=0,
+            output_tokens=0,
+            tools_called=(bypass_tool,),
+            selected_tool_correct=correct,
+            error=None,
+            llm_bypassed=True,
+        )
+
     client = anthropic.AsyncAnthropic()
     messages: list[dict] = [{"role": "user", "content": task_prompt}]
     tools_called: list[str] = []

--- a/tcp/agent/mock_executors.py
+++ b/tcp/agent/mock_executors.py
@@ -115,6 +115,18 @@ MOCK_RESPONSES: dict[str, str] = {
     "docker": '{"containers": [{"id": "abc", "status": "running"}]}',
     "python": '{"output": "Hello, World!"}',
     "jq": '{"result": {"name": "extracted_value"}}',
+    # --- Synthetic ambiguous corpus ---
+    "ripgrep": '{"matches": ["src/main.py:15:TODO fix auth"]}',
+    "http-fetch": '{"status": 200, "body": {"deploy_status": "healthy"}}',
+    "wget": '{"status": 200, "saved": "/tmp/output"}',
+    "python-exec": '{"output": "result"}',
+    "node-exec": '{"output": "result"}',
+    "tee": '{"status": "written", "bytes": 128}',
+    "editor": '{"status": "opened", "path": "/tmp/file"}',
+    "ps": '{"processes": [{"pid": 1234, "name": "postgres"}]}',
+    "pgrep": '{"pids": [1234, 1235]}',
+    "diff": '{"diff": "--- v1\\n+++ v2\\n@@ -1 +1 @@\\n-old\\n+new"}',
+    "colordiff": '{"diff": "--- v1\\n+++ v2\\n@@ -1 +1 @@\\n-old\\n+new"}',
 }
 
 _DEFAULT_RESPONSE = '{"status": "ok"}'

--- a/tcp/agent/routing_strategy.py
+++ b/tcp/agent/routing_strategy.py
@@ -1,0 +1,15 @@
+"""Pluggable routing strategy for LLM bypass decisions.
+
+The default strategy bypasses the LLM when the router resolves
+deterministically (exactly 1 survivor).  C3 can swap in a
+scoring-aware strategy without touching loop internals.
+"""
+
+from __future__ import annotations
+
+from tcp.harness.router import RouteConfidence, RouteResult
+
+
+def should_bypass_llm(result: RouteResult) -> bool:
+    """Default strategy: bypass when exactly 1 survivor."""
+    return result.confidence == RouteConfidence.DETERMINISTIC

--- a/tcp/harness/router.py
+++ b/tcp/harness/router.py
@@ -8,6 +8,7 @@ followed by non-bitmask request filters (commands, formats, modes).  The legacy
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Iterable
 
 from tcp.core.descriptors import CapabilityFlags
@@ -16,6 +17,14 @@ from .audit import AuditEntry, GatingDecision
 from .bitmask_filter import BitmaskFilterResult, EnvironmentMask, bitmask_filter
 from .gating import GateResult, RuntimeEnvironment, gate_tools
 from .models import ToolRecord, ToolSelectionRequest
+
+
+class RouteConfidence(Enum):
+    """Confidence classification for a routing decision."""
+
+    DETERMINISTIC = "deterministic"
+    AMBIGUOUS = "ambiguous"
+    NO_MATCH = "no_match"
 
 
 @dataclass(frozen=True)
@@ -29,6 +38,10 @@ class RouteResult:
     approval_required: tuple[ToolRecord, ...] = field(default_factory=tuple)
     rejected: tuple[ToolRecord, ...] = field(default_factory=tuple)
     audit_log: tuple[AuditEntry, ...] = field(default_factory=tuple)
+    confidence: RouteConfidence = RouteConfidence.NO_MATCH
+    survivor_count: int = 0
+    candidate_scores: dict[str, float] | None = None
+    score_gap: float | None = None
 
 
 def route_tool(
@@ -128,6 +141,15 @@ def route_tool(
     # --- Stage 4: selection ---
     selected = _select_best(approved, request.preferred_criteria)
 
+    # --- Stage 5: confidence classification ---
+    survivor_count = len(approved) + len(approval_required)
+    if survivor_count == 0:
+        confidence = RouteConfidence.NO_MATCH
+    elif survivor_count == 1:
+        confidence = RouteConfidence.DETERMINISTIC
+    else:
+        confidence = RouteConfidence.AMBIGUOUS
+
     return RouteResult(
         selected_tool=selected,
         bitmask_result=bitmask_result,
@@ -135,6 +157,8 @@ def route_tool(
         approval_required=tuple(approval_required),
         rejected=tuple(rejected + list(bitmask_result.rejected)),
         audit_log=tuple(audit),
+        confidence=confidence,
+        survivor_count=survivor_count,
     )
 
 

--- a/tests/unit/test_agent_benchmark.py
+++ b/tests/unit/test_agent_benchmark.py
@@ -16,9 +16,11 @@ from tcp.agent.benchmark import (
     PairedTrial,
     SmokeResult,
     build_filtered_schemas,
+    run_layered_benchmark,
     run_paired_benchmark,
     run_smoke_test,
 )
+from tcp.agent.lane_report import LaneReport
 from tcp.agent.loop import LoopMetrics
 from tcp.agent.tasks import AgentTask
 
@@ -325,3 +327,25 @@ class TestRunSmokeTest:
 
         assert not result.passed
         assert len(result.issues) > 0
+
+
+@pytest.mark.asyncio
+class TestRunLayeredBenchmark:
+    """Layered benchmark runs deterministic and ambiguous tasks."""
+
+    async def test_returns_lane_report(self):
+        call_count = 0
+
+        async def mock_loop(task_prompt, tools, mock_executor, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return _make_metrics(
+                task_name=kwargs.get("task_name", "test"),
+                tool_count=len(tools),
+            )
+
+        with patch("tcp.agent.benchmark.run_agent_loop", side_effect=mock_loop):
+            report = await run_layered_benchmark(repetitions=1)
+
+        assert isinstance(report, LaneReport)
+        assert report.deterministic_count + report.ambiguous_count + report.no_match_count > 0

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -96,6 +96,22 @@ class TestLoopMetrics:
         assert m.turns == 2
         assert m.tools_called == ("a", "b")
 
+    def test_new_routing_fields_default(self):
+        m = LoopMetrics(
+            task_name="t",
+            tool_count=5,
+            turns=1,
+            first_token_latency_ms=10.0,
+            total_response_time_ms=20.0,
+            input_tokens=100,
+            output_tokens=50,
+            tools_called=(),
+            selected_tool_correct=True,
+            error=None,
+        )
+        assert m.route_confidence == ""
+        assert m.survivor_count == 0
+
 
 @pytest.mark.asyncio
 class TestRunAgentLoop:

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -331,3 +331,67 @@ class TestRunAgentLoop:
             )
 
         assert metrics.tool_count == 15
+
+
+@pytest.mark.asyncio
+class TestBypassPath:
+    """Deterministic bypass skips the LLM entirely."""
+
+    async def test_bypass_invokes_executor_directly(self):
+        """When bypass_tool is provided, no API call is made."""
+        executor_calls = []
+
+        def tracking_executor(tool_name: str, tool_input: dict) -> str:
+            executor_calls.append(tool_name)
+            return '{"status": "ok"}'
+
+        metrics = await run_agent_loop(
+            task_prompt="Do something",
+            tools=[],
+            mock_executor=tracking_executor,
+            expected_tool="my-tool",
+            task_name="bypass-test",
+            bypass_tool="my-tool",
+        )
+
+        assert metrics.llm_bypassed is True
+        assert metrics.tools_called == ("my-tool",)
+        assert metrics.selected_tool_correct is True
+        assert metrics.turns == 0
+        assert metrics.input_tokens == 0
+        assert executor_calls == ["my-tool"]
+
+    async def test_bypass_wrong_tool_still_correct(self):
+        """Bypass tool matches expected_tool — correctness is True."""
+        metrics = await run_agent_loop(
+            task_prompt="Do something",
+            tools=[],
+            mock_executor=_noop_executor,
+            expected_tool="my-tool",
+            task_name="bypass-match",
+            bypass_tool="my-tool",
+        )
+        assert metrics.selected_tool_correct is True
+        assert metrics.llm_bypassed is True
+
+    async def test_no_bypass_when_not_specified(self):
+        """Without bypass_tool, the normal LLM path runs."""
+        mock_response = _make_response(
+            content=[_make_text_block("ok")],
+        )
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "tcp.agent.loop.anthropic.AsyncAnthropic", return_value=mock_client
+        ):
+            metrics = await run_agent_loop(
+                task_prompt="Hello",
+                tools=[{"name": "t", "description": "t", "input_schema": {"type": "object", "properties": {}}}],
+                mock_executor=_noop_executor,
+                expected_tool=None,
+                task_name="no-bypass",
+            )
+
+        assert metrics.llm_bypassed is False
+        mock_client.messages.create.assert_called_once()

--- a/tests/unit/test_ambiguous_tasks.py
+++ b/tests/unit/test_ambiguous_tasks.py
@@ -1,0 +1,51 @@
+"""Tests for the ambiguous task corpus."""
+
+from __future__ import annotations
+
+import pytest
+
+from tcp.agent.ambiguous_tasks import build_ambiguous_tasks, AmbiguousTask
+
+
+class TestAmbiguousTaskStructure:
+    """Each ambiguous task has required fields."""
+
+    def test_returns_list(self):
+        tasks = build_ambiguous_tasks()
+        assert isinstance(tasks, list)
+        assert len(tasks) >= 6
+
+    def test_all_have_required_fields(self):
+        for task in build_ambiguous_tasks():
+            assert isinstance(task, AmbiguousTask)
+            assert task.agent_task.name
+            assert task.agent_task.prompt
+            assert task.agent_task.expected_tool is not None
+            assert task.selection_request is not None
+            assert task.ambiguity_reason
+
+    def test_selection_requests_have_no_required_commands(self):
+        """Ambiguous tasks use capability flags/formats, NOT specific commands."""
+        for task in build_ambiguous_tasks():
+            assert len(task.selection_request.required_commands) == 0, (
+                f"Task {task.agent_task.name!r} has required_commands — "
+                f"ambiguous tasks must use broader filters"
+            )
+
+    def test_synthetic_tools_provided(self):
+        """Each task provides its synthetic tool records."""
+        for task in build_ambiguous_tasks():
+            assert len(task.synthetic_tools) >= 2, (
+                f"Task {task.agent_task.name!r} needs 2+ synthetic tools, "
+                f"got {len(task.synthetic_tools)}"
+            )
+
+    def test_expected_tool_in_synthetic_tools(self):
+        """The expected tool appears in the synthetic tool set."""
+        for task in build_ambiguous_tasks():
+            tool_names = {t.tool_name for t in task.synthetic_tools}
+            assert task.agent_task.expected_tool in tool_names, (
+                f"Task {task.agent_task.name!r}: expected tool "
+                f"{task.agent_task.expected_tool!r} not in synthetic tools "
+                f"{sorted(tool_names)}"
+            )

--- a/tests/unit/test_ambiguous_tasks.py
+++ b/tests/unit/test_ambiguous_tasks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from tcp.agent.ambiguous_tasks import build_ambiguous_tasks, AmbiguousTask
+from tcp.harness.gating import RuntimeEnvironment, gate_tools
 
 
 class TestAmbiguousTaskStructure:
@@ -48,4 +49,44 @@ class TestAmbiguousTaskStructure:
                 f"Task {task.agent_task.name!r}: expected tool "
                 f"{task.agent_task.expected_tool!r} not in synthetic tools "
                 f"{sorted(tool_names)}"
+            )
+
+
+class TestAmbiguousSurvivorCounts:
+    """Each ambiguous task produces 2-5 survivors from its synthetic tools."""
+
+    def test_survivor_counts_in_range(self):
+        env = RuntimeEnvironment(
+            network_enabled=True,  # allow network tools for fetch tasks
+            file_access_enabled=True,
+            stdin_enabled=True,
+            installed_tools=frozenset(),
+        )
+        for task in build_ambiguous_tasks():
+            tools = list(task.synthetic_tools)
+            result = gate_tools(tools, task.selection_request, env)
+            survivors = len(result.approved_tools) + len(result.approval_required_tools)
+            assert 2 <= survivors <= 5, (
+                f"Task {task.agent_task.name!r}: expected 2-5 survivors, "
+                f"got {survivors} (approved={len(result.approved_tools)}, "
+                f"approval_required={len(result.approval_required_tools)}, "
+                f"rejected={len(result.rejected_tools)})"
+            )
+
+    def test_expected_tool_survives_filtering(self):
+        env = RuntimeEnvironment(
+            network_enabled=True,
+            file_access_enabled=True,
+            stdin_enabled=True,
+            installed_tools=frozenset(),
+        )
+        for task in build_ambiguous_tasks():
+            tools = list(task.synthetic_tools)
+            result = gate_tools(tools, task.selection_request, env)
+            survivor_names = {t.tool_name for t in result.approved_tools}
+            survivor_names |= {t.tool_name for t in result.approval_required_tools}
+            assert task.agent_task.expected_tool in survivor_names, (
+                f"Task {task.agent_task.name!r}: expected tool "
+                f"{task.agent_task.expected_tool!r} was filtered out. "
+                f"Survivors: {sorted(survivor_names)}"
             )

--- a/tests/unit/test_ambiguous_tasks.py
+++ b/tests/unit/test_ambiguous_tasks.py
@@ -6,6 +6,7 @@ import pytest
 
 from tcp.agent.ambiguous_tasks import build_ambiguous_tasks, AmbiguousTask
 from tcp.harness.gating import RuntimeEnvironment, gate_tools
+from tcp.harness.router import RouteConfidence, route_tool
 
 
 class TestAmbiguousTaskStructure:
@@ -90,3 +91,26 @@ class TestAmbiguousSurvivorCounts:
                 f"{task.agent_task.expected_tool!r} was filtered out. "
                 f"Survivors: {sorted(survivor_names)}"
             )
+
+
+class TestEndToEndClassification:
+    """Full pipeline: ambiguous tasks get AMBIGUOUS confidence."""
+
+    def test_ambiguous_tasks_classified_ambiguous(self):
+        env = RuntimeEnvironment(
+            network_enabled=True,
+            file_access_enabled=True,
+            stdin_enabled=True,
+            installed_tools=frozenset(),
+        )
+        for task in build_ambiguous_tasks():
+            result = route_tool(
+                list(task.synthetic_tools),
+                task.selection_request,
+                env,
+            )
+            assert result.confidence == RouteConfidence.AMBIGUOUS, (
+                f"Task {task.agent_task.name!r}: expected AMBIGUOUS, "
+                f"got {result.confidence} with {result.survivor_count} survivors"
+            )
+            assert result.survivor_count >= 2

--- a/tests/unit/test_lane_report.py
+++ b/tests/unit/test_lane_report.py
@@ -1,0 +1,85 @@
+"""Tests for three-lane benchmark reporting."""
+
+from __future__ import annotations
+
+import pytest
+
+from tcp.agent.lane_report import LaneReport, build_lane_report
+from tcp.agent.loop import LoopMetrics
+
+
+def _make_metrics(
+    task_name: str = "test",
+    correct: bool = True,
+    input_tokens: int = 500,
+    bypassed: bool = False,
+    confidence: str = "deterministic",
+    survivor_count: int = 1,
+) -> LoopMetrics:
+    return LoopMetrics(
+        task_name=task_name,
+        tool_count=10,
+        turns=0 if bypassed else 2,
+        first_token_latency_ms=0.0 if bypassed else 100.0,
+        total_response_time_ms=1.0 if bypassed else 200.0,
+        input_tokens=0 if bypassed else input_tokens,
+        output_tokens=0 if bypassed else 50,
+        tools_called=("tool-a",),
+        selected_tool_correct=correct,
+        error=None,
+        llm_bypassed=bypassed,
+        route_confidence=confidence,
+        survivor_count=survivor_count,
+    )
+
+
+class TestBuildLaneReport:
+    """Lane report splits metrics by confidence."""
+
+    def test_deterministic_lane(self):
+        metrics = [
+            _make_metrics(confidence="deterministic", bypassed=True, correct=True),
+            _make_metrics(confidence="deterministic", bypassed=True, correct=True),
+        ]
+        report = build_lane_report(metrics)
+        assert report.deterministic_count == 2
+        assert report.deterministic_correct_rate == pytest.approx(1.0)
+
+    def test_ambiguous_lane(self):
+        metrics = [
+            _make_metrics(confidence="ambiguous", bypassed=False, correct=True, survivor_count=3),
+            _make_metrics(confidence="ambiguous", bypassed=False, correct=False, survivor_count=3),
+        ]
+        report = build_lane_report(metrics)
+        assert report.ambiguous_count == 2
+        assert report.ambiguous_correct_rate == pytest.approx(0.5)
+
+    def test_no_match_lane(self):
+        metrics = [
+            _make_metrics(confidence="no_match", bypassed=False, correct=True, survivor_count=0),
+        ]
+        report = build_lane_report(metrics)
+        assert report.no_match_count == 1
+
+    def test_bypass_ratio(self):
+        metrics = [
+            _make_metrics(confidence="deterministic", bypassed=True),
+            _make_metrics(confidence="deterministic", bypassed=True),
+            _make_metrics(confidence="ambiguous", bypassed=False, survivor_count=3),
+        ]
+        report = build_lane_report(metrics)
+        assert report.bypass_ratio == pytest.approx(2 / 3)
+
+    def test_ambiguous_llm_lift(self):
+        metrics = [
+            _make_metrics(confidence="ambiguous", bypassed=False, correct=True, survivor_count=3),
+            _make_metrics(confidence="ambiguous", bypassed=False, correct=True, survivor_count=3),
+        ]
+        report = build_lane_report(metrics, select_best_correct_rate=0.5)
+        assert report.ambiguous_llm_lift == pytest.approx(0.5)
+
+    def test_empty_metrics(self):
+        report = build_lane_report([])
+        assert report.deterministic_count == 0
+        assert report.ambiguous_count == 0
+        assert report.bypass_ratio == 0.0

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1,0 +1,83 @@
+"""Tests for RouteConfidence and the layered router split."""
+
+from __future__ import annotations
+
+import pytest
+
+from tcp.harness.router import RouteConfidence, RouteResult, route_tool
+from tcp.harness.gating import RuntimeEnvironment
+from tcp.harness.models import ToolRecord, ToolSelectionRequest
+
+
+def _make_record(name: str, commands: frozenset[str] = frozenset()) -> ToolRecord:
+    return ToolRecord(
+        tool_name=name,
+        descriptor_source="test",
+        descriptor_version="1.0",
+        capability_flags=0,
+        risk_level="safe",
+        commands=commands,
+    )
+
+
+def _make_env() -> RuntimeEnvironment:
+    return RuntimeEnvironment(
+        network_enabled=False,
+        file_access_enabled=True,
+        stdin_enabled=True,
+        installed_tools=frozenset(),
+    )
+
+
+class TestRouteConfidence:
+    """RouteConfidence enum values."""
+
+    def test_enum_values(self):
+        assert RouteConfidence.DETERMINISTIC.value == "deterministic"
+        assert RouteConfidence.AMBIGUOUS.value == "ambiguous"
+        assert RouteConfidence.NO_MATCH.value == "no_match"
+
+
+class TestRouteResultConfidence:
+    """route_tool sets confidence based on survivor count."""
+
+    def test_deterministic_when_one_survivor(self):
+        tools = [_make_record("only-tool", commands=frozenset({"do_thing"}))]
+        request = ToolSelectionRequest.from_kwargs(
+            required_commands={"do_thing"},
+            require_auto_approval=False,
+        )
+        result = route_tool(tools, request, _make_env())
+        assert result.confidence == RouteConfidence.DETERMINISTIC
+        assert result.survivor_count == 1
+        assert result.selected_tool is not None
+
+    def test_ambiguous_when_multiple_survivors(self):
+        tools = [
+            _make_record("tool-a"),
+            _make_record("tool-b"),
+        ]
+        request = ToolSelectionRequest.from_kwargs(
+            preferred_criteria="speed",
+            require_auto_approval=False,
+        )
+        result = route_tool(tools, request, _make_env())
+        assert result.confidence == RouteConfidence.AMBIGUOUS
+        assert result.survivor_count == 2
+
+    def test_no_match_when_zero_survivors(self):
+        tools = [_make_record("tool-a", commands=frozenset({"x"}))]
+        request = ToolSelectionRequest.from_kwargs(
+            required_commands={"nonexistent"},
+            require_auto_approval=False,
+        )
+        result = route_tool(tools, request, _make_env())
+        assert result.confidence == RouteConfidence.NO_MATCH
+        assert result.survivor_count == 0
+
+    def test_candidate_scores_none_by_default(self):
+        tools = [_make_record("t")]
+        request = ToolSelectionRequest.from_kwargs(require_auto_approval=False)
+        result = route_tool(tools, request, _make_env())
+        assert result.candidate_scores is None
+        assert result.score_gap is None

--- a/tests/unit/test_routing_strategy.py
+++ b/tests/unit/test_routing_strategy.py
@@ -1,0 +1,30 @@
+"""Tests for the LLM bypass strategy."""
+
+from __future__ import annotations
+
+from tcp.agent.routing_strategy import should_bypass_llm
+from tcp.harness.router import RouteConfidence, RouteResult
+
+
+def _make_route_result(confidence: RouteConfidence, survivor_count: int = 1) -> RouteResult:
+    return RouteResult(
+        selected_tool=None,
+        confidence=confidence,
+        survivor_count=survivor_count,
+    )
+
+
+class TestShouldBypassLlm:
+    """Default bypass strategy: bypass when DETERMINISTIC."""
+
+    def test_bypass_on_deterministic(self):
+        result = _make_route_result(RouteConfidence.DETERMINISTIC, survivor_count=1)
+        assert should_bypass_llm(result) is True
+
+    def test_no_bypass_on_ambiguous(self):
+        result = _make_route_result(RouteConfidence.AMBIGUOUS, survivor_count=3)
+        assert should_bypass_llm(result) is False
+
+    def test_no_bypass_on_no_match(self):
+        result = _make_route_result(RouteConfidence.NO_MATCH, survivor_count=0)
+        assert should_bypass_llm(result) is False


### PR DESCRIPTION
## Summary

- **Deterministic bypass**: when TCP filtering yields exactly 1 tool, skip the LLM entirely and invoke directly — zero latency, zero tokens
- **Ambiguous task corpus**: 6 new tasks where filtering yields 2-5 viable tools, requiring the LLM to choose based on prompt context
- **Three-lane reporting**: benchmark splits results into deterministic / ambiguous / no-match lanes with per-lane accuracy, latency, and token metrics
- **C3 interface seams**: `RouteResult.candidate_scores`, `score_gap`, and pluggable `should_bypass_llm()` strategy ready for graduated confidence scoring

## Architecture

`RouteConfidence` enum (DETERMINISTIC / AMBIGUOUS / NO_MATCH) on `RouteResult`. Agent loop branches on confidence: bypass path short-circuits the API call; ambiguous path sends filtered tools to the LLM as before. `LaneReport` computes `bypass_ratio` and `ambiguous_llm_lift`.

## Files changed (15 files, +1069 lines)

**New modules:** `routing_strategy.py`, `ambiguous_tasks.py`, `lane_report.py`  
**Modified:** `router.py`, `loop.py`, `benchmark.py`, `cli.py`, `mock_executors.py`  
**New tests:** `test_router.py`, `test_routing_strategy.py`, `test_ambiguous_tasks.py`, `test_lane_report.py`  
**Extended tests:** `test_agent_loop.py`, `test_agent_benchmark.py`

## Test plan

- [x] 143 unit tests pass, 1 pre-existing skip
- [x] All 6 ambiguous tasks validated: 2-5 survivors per task
- [x] End-to-end: ambiguous tasks classified as AMBIGUOUS through full `route_tool()` pipeline
- [x] CLI verified: `--layered` mode visible in `--help`
- [ ] Run `python -m tcp.agent --layered --reps 3` against live API to collect first lane metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)