### PR TITLE
feat(proxy): defer schemas for non-active visible packs

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -210,12 +210,75 @@ _SAFETY_FLOOR_TOOLS = frozenset({
 })
 
 
+_DEFERRED_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": True,
+}
+
+
 def _session_from_env() -> SessionStartEvent:
     return SessionStartEvent(
         session_id="tcp_cc_proxy",
         permission_mode=os.environ.get("TCP_PROXY_PERMISSION_MODE", "default"),
         cwd=os.environ.get("TCP_PROXY_CWD", os.getcwd()),
     )
+
+
+def _deferred_tool_surface(
+    tool: Mapping[str, Any],
+    *,
+    pack_id: str | None,
+    server: str | None,
+    reason: str | None,
+) -> dict[str, Any]:
+    """Return a minimal visible representation for a deferred tool surface.
+
+    The local runtime still knows the full tool definition; this only shrinks the
+    model-visible schema surface sent upstream.
+    """
+    name = _tool_name(tool)
+    pack_label = pack_id or "deferred-pack"
+    server_label = server or "deferred-server"
+    reason_suffix = f" via {reason}" if reason else ""
+    return {
+        "name": name,
+        "description": (
+            f"Deferred schema for {name} ({pack_label}/{server_label}{reason_suffix})."
+        ),
+        "input_schema": dict(_DEFERRED_INPUT_SCHEMA),
+    }
+
+
+def _schema_materialization_state(
+    tool_name: str,
+    *,
+    allowed_servers: frozenset[str],
+    server_pack_decisions: Mapping[str, Any],
+    server_allow_source: Mapping[str, str],
+) -> str:
+    """Classify whether a visible tool should keep full schema or deferred schema."""
+    server = _extract_mcp_server(tool_name)
+    if server is None:
+        return STATE_ACTIVE
+
+    pack_decision = server_pack_decisions.get(server)
+    allow_source = server_allow_source.get(server)
+
+    if pack_decision is not None:
+        if pack_decision.state != STATE_ACTIVE and allow_source in {
+            "workspace_allow",
+            "explicit_request",
+        }:
+            return STATE_DEFERRED
+        return pack_decision.state
+
+    if server in allowed_servers:
+        return STATE_ACTIVE
+
+    if allow_source in {"workspace_allow", "explicit_request"}:
+        return STATE_DEFERRED
+    return STATE_SUPPRESSED
 
 
 def _runtime_from_env() -> RuntimeEnvironment:
@@ -423,16 +486,44 @@ def _process_tools_array(
 
     # ── Build output tool list ───────────────────────────────────────────
     live_tools: list[Any] = []
+    materialized_schema_tools: list[str] = []
+    deferred_schema_tools: list[str] = []
+    surface_state_by_tool: dict[str, str] = {}
     for item in entries:
         orig, rec, tier, _name = item
         if rec is None:
             live_tools.append(orig)
             continue
-        if rec.tool_name in active_survivors:
-            live_tools.append(orig)
-        elif tier == ProjectionTier.FALLBACK and rec.tool_name not in server_filtered:
-            # FALLBACK tools pass through unless explicitly server-filtered
-            live_tools.append(orig)
+        survives = rec.tool_name in active_survivors or (
+            tier == ProjectionTier.FALLBACK and rec.tool_name not in server_filtered
+        )
+        if not survives:
+            continue
+
+        schema_state = _schema_materialization_state(
+            rec.tool_name,
+            allowed_servers=allowed_servers,
+            server_pack_decisions=server_pack_decisions,
+            server_allow_source=server_allow_source,
+        )
+        surface_state_by_tool[rec.tool_name] = schema_state
+
+        if mode in ("live", "live-strict") and schema_state == STATE_DEFERRED:
+            server = _extract_mcp_server(rec.tool_name)
+            pack_decision = None if server is None else server_pack_decisions.get(server)
+            live_tools.append(
+                _deferred_tool_surface(
+                    orig,
+                    pack_id=None if pack_decision is None else pack_decision.pack_id,
+                    server=server,
+                    reason=server_allow_source.get(server) if server else None,
+                )
+            )
+            deferred_schema_tools.append(rec.tool_name)
+            continue
+
+        live_tools.append(orig)
+        materialized_schema_tools.append(rec.tool_name)
 
     # ── Serialize audit log ──────────────────────────────────────────────
     audit_serial = []
@@ -494,6 +585,13 @@ def _process_tools_array(
         "heuristic_would_reject": sorted(heuristic_would_reject) if heuristic_would_reject else [],
         "safety_floor_activated": safety_floor_activated,
         "safety_floor_rescued": sorted(floor_rescued) if floor_rescued else [],
+        "materialized_schema_count": len(materialized_schema_tools),
+        "materialized_schema_tools": sorted(materialized_schema_tools),
+        "deferred_schema_count": len(deferred_schema_tools),
+        "deferred_schema_tools": sorted(deferred_schema_tools),
+        "surface_state_by_tool": dict(sorted(surface_state_by_tool.items())),
+        "tool_surface_bytes_before": len(json.dumps(tools, sort_keys=True, default=str)),
+        "tool_surface_bytes_after": len(json.dumps(live_tools, sort_keys=True, default=str)),
         "tool_count_after": len(live_tools) if mode in ("live", "live-strict") else len(tools),
         # Backward-compat aliases for TCP-MT-10 / shadow pilot scripts.
         "full_tool_count": len(tools),

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -20,7 +20,12 @@ from typing import Any, Mapping
 import httpx
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse, Response, StreamingResponse
+from starlette.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    Response,
+    StreamingResponse,
+)
 from starlette.routing import Route
 
 from tcp.derivation.request_derivation import SessionStartEvent, derive_request
@@ -149,13 +154,15 @@ def _server_alias_tokens(server_l: str) -> set[str]:
     unique_parts = tuple(dict.fromkeys(parts))
     if len(unique_parts) >= 2:
         for idx in range(len(unique_parts) - 1):
-            pair = " ".join(unique_parts[idx:idx + 2])
+            pair = " ".join(unique_parts[idx : idx + 2])
             tokens.add(pair)
-            tokens.add(" ".join(reversed(unique_parts[idx:idx + 2])))
+            tokens.add(" ".join(reversed(unique_parts[idx : idx + 2])))
         tokens.add(" ".join(unique_parts))
 
     wrapper_parts = {"plugin", "claude", "ai", "mcp"}
-    informative_parts = tuple(part for part in unique_parts if part not in wrapper_parts)
+    informative_parts = tuple(
+        part for part in unique_parts if part not in wrapper_parts
+    )
     if informative_parts:
         tokens.add(" ".join(informative_parts))
         if len(informative_parts) == 1:
@@ -173,7 +180,7 @@ def _server_alias_tokens(server_l: str) -> set[str]:
                 tokens.add(f"{informative} claude")
         elif len(informative_parts) >= 2:
             for idx in range(len(informative_parts) - 1):
-                phrase = " ".join(informative_parts[idx:idx + 2])
+                phrase = " ".join(informative_parts[idx : idx + 2])
                 tokens.add(phrase)
     return {token for token in tokens if token}
 
@@ -191,23 +198,50 @@ def _is_mcp_server_allowed(tool_name: str, allowed: frozenset[str]) -> bool:
 
 # ── Safety floor: core local coding tools that must survive live filtering ────
 
-_SAFETY_FLOOR_TOOLS = frozenset({
-    "Read", "Edit", "MultiEdit", "Write", "Glob", "Grep", "Bash",
-    "Agent", "EnterPlanMode", "ExitPlanMode", "AskUserQuestion",
-    "Skill", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet",
-    "NotebookEdit", "Think",
-    # MCP filesystem / git equivalents
-    "mcp__filesystem__read_file", "mcp__filesystem__write_file",
-    "mcp__filesystem__read_multiple_files", "mcp__filesystem__list_directory",
-    "mcp__filesystem__search_files", "mcp__filesystem__directory_tree",
-    "mcp__filesystem__create_directory", "mcp__filesystem__list_directory_with_sizes",
-    "mcp__filesystem__get_file_info",
-    "mcp__git__git_log", "mcp__git__git_diff", "mcp__git__git_status",
-    "mcp__git__git_show", "mcp__git__git_branch",
-    "mcp__git__git_diff_staged", "mcp__git__git_diff_unstaged",
-    "mcp__git__git_add", "mcp__git__git_commit", "mcp__git__git_checkout",
-    "mcp__git__git_reset", "mcp__git__git_create_branch",
-})
+_SAFETY_FLOOR_TOOLS = frozenset(
+    {
+        "Read",
+        "Edit",
+        "MultiEdit",
+        "Write",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Agent",
+        "EnterPlanMode",
+        "ExitPlanMode",
+        "AskUserQuestion",
+        "Skill",
+        "TaskCreate",
+        "TaskUpdate",
+        "TaskList",
+        "TaskGet",
+        "NotebookEdit",
+        "Think",
+        # MCP filesystem / git equivalents
+        "mcp__filesystem__read_file",
+        "mcp__filesystem__write_file",
+        "mcp__filesystem__read_multiple_files",
+        "mcp__filesystem__list_directory",
+        "mcp__filesystem__search_files",
+        "mcp__filesystem__directory_tree",
+        "mcp__filesystem__create_directory",
+        "mcp__filesystem__list_directory_with_sizes",
+        "mcp__filesystem__get_file_info",
+        "mcp__git__git_log",
+        "mcp__git__git_diff",
+        "mcp__git__git_status",
+        "mcp__git__git_show",
+        "mcp__git__git_branch",
+        "mcp__git__git_diff_staged",
+        "mcp__git__git_diff_unstaged",
+        "mcp__git__git_add",
+        "mcp__git__git_commit",
+        "mcp__git__git_checkout",
+        "mcp__git__git_reset",
+        "mcp__git__git_create_branch",
+    }
+)
 
 
 _DEFERRED_INPUT_SCHEMA = {
@@ -326,7 +360,8 @@ def _manifest_hash() -> str:
                     "active_workspaces": sorted(pack.active_workspaces),
                     "active_profiles": sorted(pack.active_profiles),
                     "active_env": {
-                        key: sorted(values) for key, values in sorted(pack.active_env.items())
+                        key: sorted(values)
+                        for key, values in sorted(pack.active_env.items())
                     },
                 }
                 for pack in _PACK_MANIFEST.packs
@@ -424,7 +459,9 @@ def _process_tools_array(
                 stage2_survivors.discard(name)
                 server_filtered.add(name)
                 continue
-            pack_decision = None if server is None else server_pack_decisions.get(server)
+            pack_decision = (
+                None if server is None else server_pack_decisions.get(server)
+            )
             pack_state = (
                 pack_decision.state if pack_decision is not None else STATE_SUPPRESSED
             )
@@ -463,9 +500,11 @@ def _process_tools_array(
     heuristic_would_reject: set[str] = set()
     if tsel.heuristic_capability_flags and gate:
         for rec_item in records:
-            if tsel.heuristic_capability_flags and (
-                rec_item.capability_flags & tsel.heuristic_capability_flags
-            ) != tsel.heuristic_capability_flags:
+            if (
+                tsel.heuristic_capability_flags
+                and (rec_item.capability_flags & tsel.heuristic_capability_flags)
+                != tsel.heuristic_capability_flags
+            ):
                 heuristic_would_reject.add(rec_item.tool_name)
 
     # ── Stage 4: Safety floor ────────────────────────────────────────────
@@ -510,7 +549,9 @@ def _process_tools_array(
 
         if mode in ("live", "live-strict") and schema_state == STATE_DEFERRED:
             server = _extract_mcp_server(rec.tool_name)
-            pack_decision = None if server is None else server_pack_decisions.get(server)
+            pack_decision = (
+                None if server is None else server_pack_decisions.get(server)
+            )
             live_tools.append(
                 _deferred_tool_surface(
                     orig,
@@ -541,7 +582,11 @@ def _process_tools_array(
     # ── Decision metadata ────────────────────────────────────────────────
     meta: dict[str, Any] = {
         "mode": mode,
-        "strategy": "conservative" if mode == "live" else ("strict" if mode == "live-strict" else "shadow"),
+        "strategy": (
+            "conservative"
+            if mode == "live"
+            else ("strict" if mode == "live-strict" else "shadow")
+        ),
         "prompt_excerpt": prompt[:240],
         "prompt_hash": hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16],
         "workspace_path": session.cwd,
@@ -567,13 +612,19 @@ def _process_tools_array(
             for pack_id, decision in sorted(pack_decisions.items())
         },
         "active_packs": sorted(
-            pack_id for pack_id, decision in pack_decisions.items() if decision.state == STATE_ACTIVE
+            pack_id
+            for pack_id, decision in pack_decisions.items()
+            if decision.state == STATE_ACTIVE
         ),
         "deferred_packs": sorted(
-            pack_id for pack_id, decision in pack_decisions.items() if decision.state == STATE_DEFERRED
+            pack_id
+            for pack_id, decision in pack_decisions.items()
+            if decision.state == STATE_DEFERRED
         ),
         "suppressed_packs": sorted(
-            pack_id for pack_id, decision in pack_decisions.items() if decision.state == STATE_SUPPRESSED
+            pack_id
+            for pack_id, decision in pack_decisions.items()
+            if decision.state == STATE_SUPPRESSED
         ),
         "workspace_allowed_servers": sorted(workspace_allowed_servers),
         "hard_allowed_servers": sorted(allowed_servers),
@@ -582,7 +633,9 @@ def _process_tools_array(
         "explicit_server_rescued": sorted(explicit_rescued) if explicit_rescued else [],
         "server_allow_source": dict(sorted(server_allow_source.items())),
         "heuristic_would_reject_count": len(heuristic_would_reject),
-        "heuristic_would_reject": sorted(heuristic_would_reject) if heuristic_would_reject else [],
+        "heuristic_would_reject": (
+            sorted(heuristic_would_reject) if heuristic_would_reject else []
+        ),
         "safety_floor_activated": safety_floor_activated,
         "safety_floor_rescued": sorted(floor_rescued) if floor_rescued else [],
         "materialized_schema_count": len(materialized_schema_tools),
@@ -590,9 +643,15 @@ def _process_tools_array(
         "deferred_schema_count": len(deferred_schema_tools),
         "deferred_schema_tools": sorted(deferred_schema_tools),
         "surface_state_by_tool": dict(sorted(surface_state_by_tool.items())),
-        "tool_surface_bytes_before": len(json.dumps(tools, sort_keys=True, default=str)),
-        "tool_surface_bytes_after": len(json.dumps(live_tools, sort_keys=True, default=str)),
-        "tool_count_after": len(live_tools) if mode in ("live", "live-strict") else len(tools),
+        "tool_surface_bytes_before": len(
+            json.dumps(tools, sort_keys=True, default=str)
+        ),
+        "tool_surface_bytes_after": len(
+            json.dumps(live_tools, sort_keys=True, default=str)
+        ),
+        "tool_count_after": (
+            len(live_tools) if mode in ("live", "live-strict") else len(tools)
+        ),
         # Backward-compat aliases for TCP-MT-10 / shadow pilot scripts.
         "full_tool_count": len(tools),
         "survivor_count": len(active_survivors),
@@ -614,7 +673,9 @@ def _process_tools_array(
     return list(tools), meta
 
 
-def _maybe_transform_messages_body(raw: bytes, mode: str) -> tuple[bytes, dict[str, Any] | None]:
+def _maybe_transform_messages_body(
+    raw: bytes, mode: str
+) -> tuple[bytes, dict[str, Any] | None]:
     try:
         body = json.loads(raw)
     except json.JSONDecodeError:
@@ -681,7 +742,9 @@ def _buffered_response_headers(response: httpx.Response, body: bytes) -> dict[st
 
 
 def _upstream_base() -> str:
-    return os.environ.get("ANTHROPIC_UPSTREAM_BASE", "https://api.anthropic.com").rstrip("/")
+    return os.environ.get(
+        "ANTHROPIC_UPSTREAM_BASE", "https://api.anthropic.com"
+    ).rstrip("/")
 
 
 async def proxy_post_messages(request: Request) -> Response:
@@ -792,7 +855,9 @@ async def handle_tcp_mode_post(request: Request) -> JSONResponse:
         return JSONResponse({"error": "invalid JSON"}, status_code=400)
     mode = data.get("mode", "")
     if mode not in VALID_MODES:
-        return JSONResponse({"error": f"mode must be one of: {', '.join(VALID_MODES)}"}, status_code=400)
+        return JSONResponse(
+            {"error": f"mode must be one of: {', '.join(VALID_MODES)}"}, status_code=400
+        )
     _write_mode(mode)
     return JSONResponse({"mode": mode, "ok": True})
 

--- a/tests/unit/test_cc_proxy_materialization.py
+++ b/tests/unit/test_cc_proxy_materialization.py
@@ -1,0 +1,136 @@
+"""TCP-IMP-12: Pack-state-aware schema materialization."""
+
+from __future__ import annotations
+
+from tcp.proxy.cc_proxy import _process_tools_array
+
+
+def _tool_by_name(tools: list[dict], name: str) -> dict:
+    for tool in tools:
+        if tool["name"] == name:
+            return tool
+    raise AssertionError(f"tool not found: {name}")
+
+
+RICH_TOOL_SET = [
+    {
+        "name": "mcp__filesystem__read_file",
+        "description": "Read a file from disk with an explicit absolute path.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "head": {"type": "integer"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "mcp__bay-view-graph__list_emails",
+        "description": "Query Bay View graph mail for matching messages.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "after": {"type": "string"},
+                "limit": {"type": "integer"},
+            },
+            "required": ["query"],
+        },
+    },
+]
+
+
+def test_active_pack_keeps_full_schema_while_workspace_allow_is_deferred(monkeypatch) -> None:
+    monkeypatch.setenv("TCP_PROXY_WORKSPACE_MCP_SERVERS", "bay-view-graph")
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Check email from Jason from today"}],
+            }
+        ]
+    }
+
+    result_tools, meta = _process_tools_array(RICH_TOOL_SET, body, "live")
+
+    fs_tool = _tool_by_name(result_tools, "mcp__filesystem__read_file")
+    deferred_tool = _tool_by_name(result_tools, "mcp__bay-view-graph__list_emails")
+
+    assert fs_tool["input_schema"]["properties"]["path"]["type"] == "string"
+    assert deferred_tool["input_schema"]["properties"] == {}
+    assert deferred_tool["input_schema"]["additionalProperties"] is True
+    assert deferred_tool["description"].startswith("Deferred schema for")
+    assert "mcp__filesystem__read_file" in meta["materialized_schema_tools"]
+    assert "mcp__bay-view-graph__list_emails" in meta["deferred_schema_tools"]
+    assert meta["surface_state_by_tool"]["mcp__filesystem__read_file"] == "active"
+    assert meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+    assert meta["tool_surface_bytes_after"] < meta["tool_surface_bytes_before"]
+
+
+def test_workspace_profile_promotes_workspace_critical_pack_to_full_schema(monkeypatch) -> None:
+    monkeypatch.setenv("TCP_PROXY_WORKSPACE_PROFILE", "bay-view")
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Check email from Jason from today"}],
+            }
+        ]
+    }
+
+    result_tools, meta = _process_tools_array(RICH_TOOL_SET, body, "live")
+    bay_tool = _tool_by_name(result_tools, "mcp__bay-view-graph__list_emails")
+
+    assert bay_tool["input_schema"]["properties"]["query"]["type"] == "string"
+    assert "mcp__bay-view-graph__list_emails" in meta["materialized_schema_tools"]
+    assert "mcp__bay-view-graph__list_emails" not in meta["deferred_schema_tools"]
+    assert meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "active"
+
+
+def test_explicitly_rescued_server_stays_visible_but_deferred(monkeypatch) -> None:
+    monkeypatch.delenv("TCP_PROXY_WORKSPACE_MCP_SERVERS", raising=False)
+    monkeypatch.delenv("TCP_PROXY_WORKSPACE_PROFILE", raising=False)
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "use mcp__bay-view-graph__list_emails to check email from Jason",
+                    }
+                ],
+            }
+        ]
+    }
+
+    result_tools, meta = _process_tools_array(RICH_TOOL_SET, body, "live")
+    bay_tool = _tool_by_name(result_tools, "mcp__bay-view-graph__list_emails")
+
+    assert bay_tool["description"].startswith("Deferred schema for")
+    assert bay_tool["input_schema"]["additionalProperties"] is True
+    assert "mcp__bay-view-graph__list_emails" in meta["explicit_server_rescued"]
+    assert "mcp__bay-view-graph__list_emails" in meta["deferred_schema_tools"]
+    assert meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+
+
+def test_suppressed_pack_remains_hidden_without_workspace_allow(monkeypatch) -> None:
+    monkeypatch.delenv("TCP_PROXY_WORKSPACE_MCP_SERVERS", raising=False)
+    monkeypatch.delenv("TCP_PROXY_WORKSPACE_PROFILE", raising=False)
+    monkeypatch.delenv("TCP_PROXY_PROFILE", raising=False)
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Read the config file"}],
+            }
+        ]
+    }
+
+    result_tools, meta = _process_tools_array(RICH_TOOL_SET, body, "live")
+    names = {tool["name"] for tool in result_tools}
+
+    assert "mcp__filesystem__read_file" in names
+    assert "mcp__bay-view-graph__list_emails" not in names
+    assert "mcp__bay-view-graph__list_emails" in meta["server_filtered"]

--- a/tests/unit/test_cc_proxy_materialization.py
+++ b/tests/unit/test_cc_proxy_materialization.py
@@ -41,13 +41,17 @@ RICH_TOOL_SET = [
 ]
 
 
-def test_active_pack_keeps_full_schema_while_workspace_allow_is_deferred(monkeypatch) -> None:
+def test_active_pack_keeps_full_schema_while_workspace_allow_is_deferred(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("TCP_PROXY_WORKSPACE_MCP_SERVERS", "bay-view-graph")
     body = {
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "text": "Check email from Jason from today"}],
+                "content": [
+                    {"type": "text", "text": "Check email from Jason from today"}
+                ],
             }
         ]
     }
@@ -64,17 +68,23 @@ def test_active_pack_keeps_full_schema_while_workspace_allow_is_deferred(monkeyp
     assert "mcp__filesystem__read_file" in meta["materialized_schema_tools"]
     assert "mcp__bay-view-graph__list_emails" in meta["deferred_schema_tools"]
     assert meta["surface_state_by_tool"]["mcp__filesystem__read_file"] == "active"
-    assert meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+    assert (
+        meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+    )
     assert meta["tool_surface_bytes_after"] < meta["tool_surface_bytes_before"]
 
 
-def test_workspace_profile_promotes_workspace_critical_pack_to_full_schema(monkeypatch) -> None:
+def test_workspace_profile_promotes_workspace_critical_pack_to_full_schema(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("TCP_PROXY_WORKSPACE_PROFILE", "bay-view")
     body = {
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "text": "Check email from Jason from today"}],
+                "content": [
+                    {"type": "text", "text": "Check email from Jason from today"}
+                ],
             }
         ]
     }
@@ -112,7 +122,9 @@ def test_explicitly_rescued_server_stays_visible_but_deferred(monkeypatch) -> No
     assert bay_tool["input_schema"]["additionalProperties"] is True
     assert "mcp__bay-view-graph__list_emails" in meta["explicit_server_rescued"]
     assert "mcp__bay-view-graph__list_emails" in meta["deferred_schema_tools"]
-    assert meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+    assert (
+        meta["surface_state_by_tool"]["mcp__bay-view-graph__list_emails"] == "deferred"
+    )
 
 
 def test_suppressed_pack_remains_hidden_without_workspace_allow(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- materialize full schemas only for tools from active packs
- keep deferred but visible families discoverable via minimal placeholder schemas
- add proxy metadata for materialized vs deferred surfaces and surface byte counts
- add focused tests for active, deferred, explicit-rescue, and suppressed pack states

## Validation
- .venv/bin/pytest -q tests/unit/test_cc_proxy_materialization.py tests/unit/test_conservative_live_filtering.py tests/unit/test_cc_proxy_runtime.py tests/unit/test_cc_proxy_pack_manifest.py tests/unit/test_cc_proxy_decisions_meta.py tests/unit/derivation/test_request_derivation.py tests/unit/test_cc_proxy_projection.py

## Closes
- refs #37