### PR TITLE
fix(proxy): force Accept-Encoding: identity and add tap_skipped field (TCP-IMP-15)

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -766,6 +766,7 @@ def _write_decision_record(
     req_ts: float,
     meta: dict[str, Any],
     first_tool_name: str | None,
+    tap_skipped: bool = False,
 ) -> None:
     """Write (or rewrite) the enriched decisions.jsonl entry for this turn."""
     expected_tool_name = _compute_expected_tool_name(meta)
@@ -782,6 +783,7 @@ def _write_decision_record(
             "first_tool_name": first_tool_name,
             "expected_tool_name": expected_tool_name,
             "first_tool_correct": first_tool_correct,
+            "tap_skipped": tap_skipped,
         },
     )
 
@@ -843,6 +845,8 @@ async def proxy_post_messages(request: Request) -> Response:
     if request.url.query:
         url = f"{url}?{request.url.query}"
     headers = _forward_headers(request)
+    # Force uncompressed upstream responses so the SSE tap can always parse.
+    headers["Accept-Encoding"] = "identity"
     stream = False
     try:
         parsed = json.loads(transformed)
@@ -862,7 +866,7 @@ async def proxy_post_messages(request: Request) -> Response:
     except Exception:
         # On upstream error: still write a decision record without tool data.
         if meta is not None:
-            _write_decision_record(req_ts, meta, None)
+            _write_decision_record(req_ts, meta, None, tap_skipped=True)
         await client.aclose()
         raise
 
@@ -870,6 +874,8 @@ async def proxy_post_messages(request: Request) -> Response:
         # Determine whether we can tap the SSE stream for tool names.
         # Skip tapping if the response body is compressed — compressed SSE
         # cannot be parsed from raw bytes without decompression buffering.
+        # With Accept-Encoding: identity forced above, this should always be
+        # uncompressed, but we keep the guard in case of upstream surprises.
         content_enc = response.headers.get("content-encoding", "").lower()
         can_tap = meta is not None and content_enc not in ("gzip", "br", "deflate", "zstd")
         # State shared by body_iter closure.
@@ -888,7 +894,7 @@ async def proxy_post_messages(request: Request) -> Response:
                             # Write the decision record as soon as we know the
                             # first tool (or that the model called no tool).
                             assert meta is not None
-                            _write_decision_record(req_ts, meta, tool_name)
+                            _write_decision_record(req_ts, meta, tool_name, tap_skipped=False)
                             _tap["done"] = True
                             _tap["buf"] = b""  # release buffer memory
             finally:
@@ -896,11 +902,11 @@ async def proxy_post_messages(request: Request) -> Response:
                     # Stream ended without a message_stop or tool event
                     # (e.g. non-200, network error). Write with null tool.
                     assert meta is not None
-                    _write_decision_record(req_ts, meta, None)
+                    _write_decision_record(req_ts, meta, None, tap_skipped=False)
                     _tap["done"] = True
                 elif meta is not None and not can_tap:
                     # Compressed stream or no meta: write without tool data.
-                    _write_decision_record(req_ts, meta, None)
+                    _write_decision_record(req_ts, meta, None, tap_skipped=True)
                 await response.aclose()
                 await client.aclose()
 
@@ -917,7 +923,7 @@ async def proxy_post_messages(request: Request) -> Response:
         # Non-streaming: extract first tool from the full response body.
         first_tool = _first_tool_from_response_body(content) if meta is not None else None
         if meta is not None:
-            _write_decision_record(req_ts, meta, first_tool)
+            _write_decision_record(req_ts, meta, first_tool, tap_skipped=False)
         return Response(
             content=content,
             status_code=response.status_code,

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -844,8 +844,13 @@ async def proxy_post_messages(request: Request) -> Response:
     url = f"{_upstream_base()}/v1/messages"
     if request.url.query:
         url = f"{url}?{request.url.query}"
-    headers = _forward_headers(request)
-    # Force uncompressed upstream responses so the SSE tap can always parse.
+    # Strip any client-supplied accept-encoding (case-insensitive) then force
+    # identity so upstream never compresses SSE and the tap can always parse.
+    headers = {
+        k: v
+        for k, v in _forward_headers(request).items()
+        if k.lower() != "accept-encoding"
+    }
     headers["Accept-Encoding"] = "identity"
     stream = False
     try:
@@ -879,6 +884,8 @@ async def proxy_post_messages(request: Request) -> Response:
         content_enc = response.headers.get("content-encoding", "").lower()
         can_tap = meta is not None and content_enc not in ("gzip", "br", "deflate", "zstd")
         # State shared by body_iter closure.
+        # _tap["buf"] holds only the unparsed tail (incomplete last line) so that
+        # _first_tool_from_sse_buf never rescans already-consumed bytes (O(n) total).
         _tap: dict[str, Any] = {"buf": b"", "done": False}
 
         async def body_iter() -> Any:
@@ -888,8 +895,8 @@ async def proxy_post_messages(request: Request) -> Response:
                 async for chunk in response.aiter_raw():
                     yield chunk
                     if can_tap and not _tap["done"]:
-                        _tap["buf"] += chunk
-                        tool_name, ended = _first_tool_from_sse_buf(_tap["buf"])
+                        combined = _tap["buf"] + chunk
+                        tool_name, ended = _first_tool_from_sse_buf(combined)
                         if tool_name is not None or ended:
                             # Write the decision record as soon as we know the
                             # first tool (or that the model called no tool).
@@ -897,6 +904,12 @@ async def proxy_post_messages(request: Request) -> Response:
                             _write_decision_record(req_ts, meta, tool_name, tap_skipped=False)
                             _tap["done"] = True
                             _tap["buf"] = b""  # release buffer memory
+                        else:
+                            # Retain only bytes after the last newline so the
+                            # next chunk completes any split line without
+                            # re-scanning already-parsed data (keeps O(n) total).
+                            last_nl = combined.rfind(b"\n")
+                            _tap["buf"] = combined[last_nl + 1:] if last_nl >= 0 else combined
             finally:
                 if can_tap and not _tap["done"]:
                     # Stream ended without a message_stop or tool event

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -635,9 +635,10 @@ def _process_tools_array(
         "pack_promotion_triggered": bool(workspace_rescued or explicit_rescued),
         # description_similarity_max: max pairwise SequenceMatcher ratio
         # between active-survivor tool descriptions. Measures confusability
-        # of the survivor set. NOTE: first_tool_name / expected_tool_name /
-        # first_tool_correct are BLOCKED at proxy layer — proxy does not
-        # observe response content.
+        # of the survivor set.
+        # first_tool_name / expected_tool_name / first_tool_correct are
+        # populated by the response tap in proxy_post_messages after the
+        # upstream response is observed.
         "description_similarity_max": _max_description_similarity_proxy(
             [
                 orig
@@ -685,6 +686,104 @@ def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
     line = json.dumps(record, default=str) + "\n"
     with path.open("a", encoding="utf-8") as fh:
         fh.write(line)
+
+
+# ── Response tap helpers ───────────────────────────────────────────────────────
+
+
+def _compute_expected_tool_name(meta: dict[str, Any] | None) -> str | None:
+    """Derive expected first tool from request-side survivor metadata.
+
+    Rules (per spec):
+      - survivor_count == 1  → use that single survivor as expected tool
+      - survivor_count >= 2  → no unambiguous expectation; return None
+      - otherwise            → return None
+    """
+    if not meta:
+        return None
+    count = meta.get("survivor_count", 0)
+    survivors = meta.get("survivor_names_sorted", [])
+    if count == 1 and len(survivors) == 1:
+        return survivors[0]
+    return None
+
+
+def _first_tool_from_response_body(body: bytes) -> str | None:
+    """Extract first tool_use block name from a non-streamed Anthropic response."""
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    for block in data.get("content", []):
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            name = block.get("name")
+            return name if isinstance(name, str) else None
+    return None
+
+
+def _first_tool_from_sse_buf(buf: bytes) -> tuple[str | None, bool]:
+    """Scan an SSE byte buffer for the first tool_use content block.
+
+    Returns ``(tool_name, stream_ended)`` where:
+      - ``tool_name`` is the name of the first tool_use block, or None
+      - ``stream_ended`` is True when a ``message_stop`` event was seen
+
+    Scans only ``data:`` lines and handles partial final lines gracefully
+    (incomplete lines are skipped — they will appear in the next chunk).
+    """
+    try:
+        text = buf.decode("utf-8", errors="replace")
+    except Exception:
+        return None, False
+
+    stream_ended = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            continue
+        payload = stripped[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        event_type = data.get("type")
+        if event_type == "content_block_start":
+            cb = data.get("content_block", {})
+            if isinstance(cb, dict) and cb.get("type") == "tool_use":
+                name = cb.get("name")
+                return (name if isinstance(name, str) else None), False
+        elif event_type == "message_stop":
+            stream_ended = True
+
+    return None, stream_ended
+
+
+def _write_decision_record(
+    req_ts: float,
+    meta: dict[str, Any],
+    first_tool_name: str | None,
+) -> None:
+    """Write (or rewrite) the enriched decisions.jsonl entry for this turn."""
+    expected_tool_name = _compute_expected_tool_name(meta)
+    first_tool_correct: bool | None = None
+    if first_tool_name is not None and expected_tool_name is not None:
+        first_tool_correct = first_tool_name == expected_tool_name
+
+    _append_jsonl(
+        DECISIONS_LOG,
+        {
+            "ts": req_ts,
+            "path": "/v1/messages",
+            **meta,
+            "first_tool_name": first_tool_name,
+            "expected_tool_name": expected_tool_name,
+            "first_tool_correct": first_tool_correct,
+        },
+    )
 
 
 def _forward_headers(request: Request) -> dict[str, str]:
@@ -735,12 +834,10 @@ def _upstream_base() -> str:
 async def proxy_post_messages(request: Request) -> Response:
     mode = _read_mode()
     raw = await request.body()
+    req_ts = time.time()
     transformed, meta = _maybe_transform_messages_body(raw, mode)
-    if meta is not None:
-        _append_jsonl(
-            DECISIONS_LOG,
-            {"ts": time.time(), "path": "/v1/messages", **meta},
-        )
+    # Decision record is written AFTER response tapping so first_tool_name,
+    # expected_tool_name, and first_tool_correct can be included in one record.
 
     url = f"{_upstream_base()}/v1/messages"
     if request.url.query:
@@ -763,10 +860,20 @@ async def proxy_post_messages(request: Request) -> Response:
         )
         response = await client.send(req, stream=stream)
     except Exception:
+        # On upstream error: still write a decision record without tool data.
+        if meta is not None:
+            _write_decision_record(req_ts, meta, None)
         await client.aclose()
         raise
 
     if stream:
+        # Determine whether we can tap the SSE stream for tool names.
+        # Skip tapping if the response body is compressed — compressed SSE
+        # cannot be parsed from raw bytes without decompression buffering.
+        content_enc = response.headers.get("content-encoding", "").lower()
+        can_tap = meta is not None and content_enc not in ("gzip", "br", "deflate", "zstd")
+        # State shared by body_iter closure.
+        _tap: dict[str, Any] = {"buf": b"", "done": False}
 
         async def body_iter() -> Any:
             try:
@@ -774,7 +881,26 @@ async def proxy_post_messages(request: Request) -> Response:
                 # clients that still see Content-Encoding: gzip (ZlibError).
                 async for chunk in response.aiter_raw():
                     yield chunk
+                    if can_tap and not _tap["done"]:
+                        _tap["buf"] += chunk
+                        tool_name, ended = _first_tool_from_sse_buf(_tap["buf"])
+                        if tool_name is not None or ended:
+                            # Write the decision record as soon as we know the
+                            # first tool (or that the model called no tool).
+                            assert meta is not None
+                            _write_decision_record(req_ts, meta, tool_name)
+                            _tap["done"] = True
+                            _tap["buf"] = b""  # release buffer memory
             finally:
+                if can_tap and not _tap["done"]:
+                    # Stream ended without a message_stop or tool event
+                    # (e.g. non-200, network error). Write with null tool.
+                    assert meta is not None
+                    _write_decision_record(req_ts, meta, None)
+                    _tap["done"] = True
+                elif meta is not None and not can_tap:
+                    # Compressed stream or no meta: write without tool data.
+                    _write_decision_record(req_ts, meta, None)
                 await response.aclose()
                 await client.aclose()
 
@@ -788,6 +914,10 @@ async def proxy_post_messages(request: Request) -> Response:
     try:
         content = await response.aread()
         hdrs = _buffered_response_headers(response, content)
+        # Non-streaming: extract first tool from the full response body.
+        first_tool = _first_tool_from_response_body(content) if meta is not None else None
+        if meta is not None:
+            _write_decision_record(req_ts, meta, first_tool)
         return Response(
             content=content,
             status_code=response.status_code,

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -1,16 +1,26 @@
-"""Upstream header forwarding must not pin stale Content-Length."""
+"""Upstream header forwarding must not pin stale Content-Length.
+
+Also covers:
+- Accept-Encoding: identity override (TCP-IMP-15)
+- tap_skipped field presence and correctness in decision records (TCP-IMP-15)
+"""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import httpx
 from starlette.requests import Request
 
 from tcp.proxy.cc_proxy import (
+    DECISIONS_LOG,
     _buffered_response_headers,
     _forward_headers,
     _streaming_response_headers,
+    _write_decision_record,
     build_app,
 )
 
@@ -76,3 +86,86 @@ def test_catch_all_proxy_route_accepts_post() -> None:
     app = build_app()
     catch_all = next(route for route in app.routes if getattr(route, "path", None) == "/{path:path}")
     assert "POST" in catch_all.methods
+
+
+# ── TCP-IMP-15: Accept-Encoding override ──────────────────────────────────────
+
+def test_forward_headers_accept_encoding_overridden() -> None:
+    """Outgoing upstream request must carry Accept-Encoding: identity regardless
+    of what the client sent."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": "POST",
+        "path": "/v1/messages",
+        "raw_path": b"/v1/messages",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"accept-encoding", b"gzip, br"),
+            (b"x-api-key", b"sk-test"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8742),
+        "scheme": "http",
+        "root_path": "",
+    }
+
+    async def empty_receive() -> dict:
+        return {"type": "http.disconnect"}
+
+    req = Request(scope, empty_receive)
+    # _forward_headers preserves the client value; the override happens in
+    # proxy_post_messages after this call. Verify the override site works by
+    # simulating the same mutation pattern used in the proxy.
+    hdrs = _forward_headers(req)
+    hdrs["Accept-Encoding"] = "identity"
+    assert hdrs["Accept-Encoding"] == "identity"
+
+
+# ── TCP-IMP-15: tap_skipped field presence ────────────────────────────────────
+
+def _make_meta() -> dict:
+    return {
+        "mode": "shadow",
+        "survivor_names_sorted": [],
+        "suppressed_names_sorted": [],
+        "total_tools_before": 0,
+        "total_tools_after": 0,
+        "description_similarity_max": None,
+        "task_prompt_hash": None,
+        "session_start_event": None,
+        "derived_intent": None,
+        "derivation_method": None,
+    }
+
+
+def test_decision_record_tap_skipped_field_always_present() -> None:
+    """Every decision record must include a tap_skipped boolean key."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "decisions.jsonl"
+        with patch("tcp.proxy.cc_proxy.DECISIONS_LOG", log_path):
+            _write_decision_record(1.0, _make_meta(), None, tap_skipped=False)
+        record = json.loads(log_path.read_text())
+        assert "tap_skipped" in record
+        assert isinstance(record["tap_skipped"], bool)
+
+
+def test_decision_record_tap_skipped_true_when_can_tap_false() -> None:
+    """tap_skipped must be True when can_tap is False (compressed response)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "decisions.jsonl"
+        with patch("tcp.proxy.cc_proxy.DECISIONS_LOG", log_path):
+            _write_decision_record(1.0, _make_meta(), None, tap_skipped=True)
+        record = json.loads(log_path.read_text())
+        assert record["tap_skipped"] is True
+
+
+def test_decision_record_tap_skipped_false_when_can_tap_true() -> None:
+    """tap_skipped must be False when can_tap is True (uncompressed response)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "decisions.jsonl"
+        with patch("tcp.proxy.cc_proxy.DECISIONS_LOG", log_path):
+            _write_decision_record(1.0, _make_meta(), "bash", tap_skipped=False)
+        record = json.loads(log_path.read_text())
+        assert record["tap_skipped"] is False

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -13,10 +13,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 from starlette.requests import Request
+from starlette.testclient import TestClient
 
 from tcp.proxy.cc_proxy import (
-    DECISIONS_LOG,
     _buffered_response_headers,
     _forward_headers,
     _streaming_response_headers,
@@ -90,37 +91,47 @@ def test_catch_all_proxy_route_accepts_post() -> None:
 
 # ── TCP-IMP-15: Accept-Encoding override ──────────────────────────────────────
 
-def test_forward_headers_accept_encoding_overridden() -> None:
-    """Outgoing upstream request must carry Accept-Encoding: identity regardless
-    of what the client sent."""
-    scope = {
-        "type": "http",
-        "asgi": {"version": "3.0"},
-        "method": "POST",
-        "path": "/v1/messages",
-        "raw_path": b"/v1/messages",
-        "query_string": b"",
-        "headers": [
-            (b"content-type", b"application/json"),
-            (b"accept-encoding", b"gzip, br"),
-            (b"x-api-key", b"sk-test"),
-        ],
-        "client": ("127.0.0.1", 1234),
-        "server": ("127.0.0.1", 8742),
-        "scheme": "http",
-        "root_path": "",
-    }
+def test_proxy_sends_exactly_one_accept_encoding_identity() -> None:
+    """proxy_post_messages must send exactly Accept-Encoding: identity upstream,
+    even when the client supplied gzip/br — no duplicate headers."""
+    captured: list[httpx.Request] = []
 
-    async def empty_receive() -> dict:
-        return {"type": "http.disconnect"}
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        body = json.dumps({"id": "msg_1", "type": "message", "role": "assistant",
+                           "content": [], "model": "claude-3-5-sonnet-20241022",
+                           "stop_reason": "end_turn", "stop_sequence": None,
+                           "usage": {"input_tokens": 1, "output_tokens": 1}})
+        return httpx.Response(200, content=body.encode(),
+                              headers={"content-type": "application/json"})
 
-    req = Request(scope, empty_receive)
-    # _forward_headers preserves the client value; the override happens in
-    # proxy_post_messages after this call. Verify the override site works by
-    # simulating the same mutation pattern used in the proxy.
-    hdrs = _forward_headers(req)
-    hdrs["Accept-Encoding"] = "identity"
-    assert hdrs["Accept-Encoding"] == "identity"
+    transport = httpx.MockTransport(handler)
+    _real_AsyncClient = httpx.AsyncClient
+
+    def _patched_client(**kw: object) -> httpx.AsyncClient:
+        kw.pop("transport", None)
+        return _real_AsyncClient(transport=transport, **kw)  # type: ignore[arg-type]
+
+    with patch("tcp.proxy.cc_proxy.httpx.AsyncClient", _patched_client):
+        with patch("tcp.proxy.cc_proxy._read_mode", return_value="shadow"):
+            app = build_app()
+            client = TestClient(app)
+            payload = json.dumps({"model": "claude-3-5-sonnet-20241022",
+                                  "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]})
+            client.post(
+                "/v1/messages",
+                content=payload,
+                headers={"content-type": "application/json",
+                         "x-api-key": "sk-test",
+                         "accept-encoding": "gzip, br"},
+            )
+
+    assert len(captured) == 1, "expected exactly one upstream request"
+    req = captured[0]
+    ae_values = [v for k, v in req.headers.items() if k.lower() == "accept-encoding"]
+    assert ae_values == ["identity"], (
+        f"expected exactly ['identity'] but got {ae_values}"
+    )
 
 
 # ── TCP-IMP-15: tap_skipped field presence ────────────────────────────────────

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -16,8 +16,6 @@ import json
 import time
 from pathlib import Path
 
-import pytest
-
 from tcp.proxy.cc_proxy import (
     _compute_expected_tool_name,
     _first_tool_from_response_body,

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -1,0 +1,321 @@
+"""Tests for TCP-IMP-14: response-tap helpers in cc_proxy.
+
+Covers:
+ - SSE first-tool extraction (normal, cross-chunk-boundary, no-tool)
+ - Non-streamed JSON extraction
+ - expected_tool_name derivation
+ - first_tool_correct computation
+ - decisions.jsonl enrichment (one record per turn)
+ - backward compatibility (new fields present with correct types)
+ - latency guard (tap overhead is negligible)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from tcp.proxy.cc_proxy import (
+    _compute_expected_tool_name,
+    _first_tool_from_response_body,
+    _first_tool_from_sse_buf,
+    _write_decision_record,
+)
+
+# ── SSE chunk helpers ──────────────────────────────────────────────────────────
+
+
+def _sse_content_block_start(name: str, index: int = 0) -> bytes:
+    data = json.dumps(
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "tool_use", "id": "toolu_abc", "name": name, "input": {}},
+        }
+    )
+    return f"event: content_block_start\ndata: {data}\n\n".encode()
+
+
+def _sse_text_block_start(index: int = 0) -> bytes:
+    data = json.dumps(
+        {"type": "content_block_start", "index": index, "content_block": {"type": "text", "text": ""}}
+    )
+    return f"event: content_block_start\ndata: {data}\n\n".encode()
+
+
+def _sse_message_stop() -> bytes:
+    data = json.dumps({"type": "message_stop"})
+    return f"event: message_stop\ndata: {data}\n\n".encode()
+
+
+def _sse_message_start() -> bytes:
+    data = json.dumps({"type": "message_start", "message": {"role": "assistant"}})
+    return f"event: message_start\ndata: {data}\n\n".encode()
+
+
+# ── Tests: _first_tool_from_sse_buf ───────────────────────────────────────────
+
+
+class TestFirstToolFromSseBuf:
+    def test_single_chunk_with_tool_use(self):
+        buf = _sse_message_start() + _sse_content_block_start("Bash")
+        tool, ended = _first_tool_from_sse_buf(buf)
+        assert tool == "Bash"
+        assert ended is False
+
+    def test_text_block_then_tool_block(self):
+        buf = _sse_text_block_start(0) + _sse_content_block_start("mcp__fs__read_file", index=1)
+        tool, ended = _first_tool_from_sse_buf(buf)
+        # text block is not tool_use; tool block is second
+        assert tool == "mcp__fs__read_file"
+        assert ended is False
+
+    def test_no_tool_call_message_stop(self):
+        buf = _sse_message_start() + _sse_text_block_start(0) + _sse_message_stop()
+        tool, ended = _first_tool_from_sse_buf(buf)
+        assert tool is None
+        assert ended is True
+
+    def test_empty_buffer(self):
+        tool, ended = _first_tool_from_sse_buf(b"")
+        assert tool is None
+        assert ended is False
+
+    def test_partial_data_line_not_parsed(self):
+        """Incomplete final line is skipped gracefully (no crash, no false positive)."""
+        full = _sse_content_block_start("Bash")
+        # Truncate midway through the last data line
+        partial = full[: len(full) // 2]
+        tool, ended = _first_tool_from_sse_buf(partial)
+        # May or may not find tool depending on where truncation lands,
+        # but must not raise.
+        assert isinstance(tool, (str, type(None)))
+        assert isinstance(ended, bool)
+
+    def test_tool_use_spans_chunk_boundary(self):
+        """Tool name arrives split across two chunks — combine and detect."""
+        full_chunk = _sse_content_block_start("my_special_tool")
+        split = len(full_chunk) // 2
+        chunk1 = full_chunk[:split]
+        chunk2 = full_chunk[split:]
+
+        # First chunk alone: might not have the full JSON
+        tool1, ended1 = _first_tool_from_sse_buf(chunk1)
+        # Second chunk combined: must detect the tool
+        tool2, ended2 = _first_tool_from_sse_buf(chunk1 + chunk2)
+        assert tool2 == "my_special_tool"
+        assert ended2 is False
+
+    def test_non_utf8_bytes_do_not_raise(self):
+        buf = b"\xff\xfe" + _sse_content_block_start("safe_tool")
+        tool, ended = _first_tool_from_sse_buf(buf)
+        # Corrupted prefix shouldn't prevent parsing of valid subsequent lines
+        assert isinstance(tool, (str, type(None)))
+
+    def test_malformed_json_skipped(self):
+        malformed = b"event: content_block_start\ndata: {not valid json}\n\n"
+        good = _sse_content_block_start("real_tool")
+        tool, ended = _first_tool_from_sse_buf(malformed + good)
+        assert tool == "real_tool"
+
+
+# ── Tests: _first_tool_from_response_body ─────────────────────────────────────
+
+
+class TestFirstToolFromResponseBody:
+    def test_non_streaming_tool_use(self):
+        body = json.dumps(
+            {
+                "type": "message",
+                "content": [
+                    {"type": "text", "text": "Sure"},
+                    {"type": "tool_use", "id": "toolu_x", "name": "mcp__git__status", "input": {}},
+                ],
+            }
+        ).encode()
+        assert _first_tool_from_response_body(body) == "mcp__git__status"
+
+    def test_non_streaming_text_only(self):
+        body = json.dumps(
+            {"type": "message", "content": [{"type": "text", "text": "Hello"}]}
+        ).encode()
+        assert _first_tool_from_response_body(body) is None
+
+    def test_empty_content_list(self):
+        body = json.dumps({"type": "message", "content": []}).encode()
+        assert _first_tool_from_response_body(body) is None
+
+    def test_invalid_json(self):
+        assert _first_tool_from_response_body(b"not json") is None
+
+    def test_multiple_tool_blocks_returns_first(self):
+        body = json.dumps(
+            {
+                "content": [
+                    {"type": "tool_use", "name": "tool_a", "id": "1", "input": {}},
+                    {"type": "tool_use", "name": "tool_b", "id": "2", "input": {}},
+                ]
+            }
+        ).encode()
+        assert _first_tool_from_response_body(body) == "tool_a"
+
+
+# ── Tests: _compute_expected_tool_name ────────────────────────────────────────
+
+
+class TestComputeExpectedToolName:
+    def test_single_survivor(self):
+        meta = {"survivor_count": 1, "survivor_names_sorted": ["mcp__git__status"]}
+        assert _compute_expected_tool_name(meta) == "mcp__git__status"
+
+    def test_two_survivors_returns_none(self):
+        meta = {"survivor_count": 2, "survivor_names_sorted": ["tool_a", "tool_b"]}
+        assert _compute_expected_tool_name(meta) is None
+
+    def test_zero_survivors_returns_none(self):
+        meta = {"survivor_count": 0, "survivor_names_sorted": []}
+        assert _compute_expected_tool_name(meta) is None
+
+    def test_none_meta_returns_none(self):
+        assert _compute_expected_tool_name(None) is None
+
+    def test_missing_fields_returns_none(self):
+        assert _compute_expected_tool_name({}) is None
+
+    def test_survivor_count_mismatch_with_list(self):
+        # count says 1 but list is empty → return None (defensive)
+        meta = {"survivor_count": 1, "survivor_names_sorted": []}
+        assert _compute_expected_tool_name(meta) is None
+
+
+# ── Tests: first_tool_correct computation ─────────────────────────────────────
+
+
+class TestFirstToolCorrect:
+    """first_tool_correct is computed inside _write_decision_record.
+    Test by reading what was written to decisions.jsonl."""
+
+    def _read_last_record(self, path: Path) -> dict:
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        return json.loads(lines[-1])
+
+    def test_correct_when_names_match(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"survivor_count": 1, "survivor_names_sorted": ["Bash"]}
+        _write_decision_record(time.time(), meta, "Bash")
+        rec = self._read_last_record(log)
+        assert rec["first_tool_correct"] is True
+
+    def test_incorrect_when_names_differ(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"survivor_count": 1, "survivor_names_sorted": ["Bash"]}
+        _write_decision_record(time.time(), meta, "mcp__git__status")
+        rec = self._read_last_record(log)
+        assert rec["first_tool_correct"] is False
+
+    def test_none_when_first_tool_name_is_null(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"survivor_count": 1, "survivor_names_sorted": ["Bash"]}
+        _write_decision_record(time.time(), meta, None)
+        rec = self._read_last_record(log)
+        assert rec["first_tool_correct"] is None
+
+    def test_none_when_expected_is_null(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"survivor_count": 2, "survivor_names_sorted": ["a", "b"]}
+        _write_decision_record(time.time(), meta, "a")
+        rec = self._read_last_record(log)
+        assert rec["first_tool_correct"] is None
+        assert rec["expected_tool_name"] is None
+
+
+# ── Tests: backward compatibility ─────────────────────────────────────────────
+
+
+class TestBackwardCompatibility:
+    """New fields must be present and typed correctly so existing readers
+    can use .get() without crashing."""
+
+    def _read_last_record(self, path: Path) -> dict:
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        return json.loads(lines[-1])
+
+    def test_new_fields_always_present(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"survivor_count": 1, "survivor_names_sorted": ["Bash"]}
+        _write_decision_record(time.time(), meta, "Bash")
+        rec = self._read_last_record(log)
+        assert "first_tool_name" in rec
+        assert "expected_tool_name" in rec
+        assert "first_tool_correct" in rec
+
+    def test_record_is_valid_json(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        meta = {"mode": "shadow", "survivor_count": 0, "survivor_names_sorted": []}
+        _write_decision_record(time.time(), meta, None)
+        line = log.read_text(encoding="utf-8").strip()
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict)
+
+    def test_ts_field_is_numeric(self, tmp_path, monkeypatch):
+        log = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
+        ts = time.time()
+        meta = {"survivor_count": 0, "survivor_names_sorted": []}
+        _write_decision_record(ts, meta, None)
+        rec = self._read_last_record(log)
+        assert isinstance(rec["ts"], float)
+        assert abs(rec["ts"] - ts) < 1.0
+
+
+# ── Tests: latency guard ───────────────────────────────────────────────────────
+
+
+class TestResponseTapLatency:
+    """The SSE tap must add negligible overhead on each chunk inspection."""
+
+    def test_sse_buf_scan_latency(self):
+        """Scanning a realistic 4 KB SSE buffer must complete in under 1 ms."""
+        # Build a realistic-sized buffer: message_start + text delta * N + message_stop
+        chunks = [_sse_message_start()]
+        for i in range(20):
+            data = json.dumps({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "word " * 10}})
+            chunks.append(f"event: content_block_delta\ndata: {data}\n\n".encode())
+        chunks.append(_sse_message_stop())
+        buf = b"".join(chunks)
+
+        N = 1000
+        start = time.perf_counter()
+        for _ in range(N):
+            _first_tool_from_sse_buf(buf)
+        elapsed_ms = (time.perf_counter() - start) * 1000 / N
+        # Each scan must be under 1 ms on any reasonable hardware.
+        assert elapsed_ms < 1.0, f"SSE scan took {elapsed_ms:.3f} ms per call"
+
+    def test_response_body_parse_latency(self):
+        """Parsing a realistic 2 KB non-streaming response must be under 1 ms."""
+        body = json.dumps(
+            {
+                "type": "message",
+                "content": [
+                    {"type": "text", "text": "I'll help you with that. " * 20},
+                    {"type": "tool_use", "id": "toolu_x", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            }
+        ).encode()
+
+        N = 1000
+        start = time.perf_counter()
+        for _ in range(N):
+            _first_tool_from_response_body(body)
+        elapsed_ms = (time.perf_counter() - start) * 1000 / N
+        assert elapsed_ms < 1.0, f"Response parse took {elapsed_ms:.3f} ms per call"


### PR DESCRIPTION
Fixes blind SSE tap from compressed upstream responses and adds tap_skipped audit field. Closes #57 (live MT-12 validation pending).