### PR TITLE
feat(proxy): loosen expected_tool_name derivation to survivor_count ≤ 3 (TCP-IMP-16)

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -691,19 +691,23 @@ def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
 # ── Response tap helpers ───────────────────────────────────────────────────────
 
 
+_EXPECTED_TOOL_MAX_SURVIVORS: int = 3  # TCP-IMP-16: emit when survivor_count ≤ k
+
+
 def _compute_expected_tool_name(meta: dict[str, Any] | None) -> str | None:
     """Derive expected first tool from request-side survivor metadata.
 
-    Rules (per spec):
-      - survivor_count == 1  → use that single survivor as expected tool
-      - survivor_count >= 2  → no unambiguous expectation; return None
-      - otherwise            → return None
+    Rules (TCP-IMP-16, k=3):
+      - 1 ≤ survivor_count ≤ k  → first sorted survivor name is the expectation
+      - survivor_count > k       → shortlist too broad; return None
+      - survivor_count == 0      → nothing filtered in; return None
+      - otherwise                → return None
     """
     if not meta:
         return None
     count = meta.get("survivor_count", 0)
     survivors = meta.get("survivor_names_sorted", [])
-    if count == 1 and len(survivors) == 1:
+    if 1 <= count <= _EXPECTED_TOOL_MAX_SURVIVORS and len(survivors) >= 1:
         return survivors[0]
     return None
 

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -169,8 +169,17 @@ class TestComputeExpectedToolName:
         meta = {"survivor_count": 1, "survivor_names_sorted": ["mcp__git__status"]}
         assert _compute_expected_tool_name(meta) == "mcp__git__status"
 
-    def test_two_survivors_returns_none(self):
+    # TCP-IMP-16: loosen threshold to k=3 — 2 survivors now emits first survivor
+    def test_two_survivors_returns_first_survivor(self):
         meta = {"survivor_count": 2, "survivor_names_sorted": ["tool_a", "tool_b"]}
+        assert _compute_expected_tool_name(meta) == "tool_a"
+
+    def test_three_survivors_returns_first_survivor(self):
+        meta = {"survivor_count": 3, "survivor_names_sorted": ["alpha", "beta", "gamma"]}
+        assert _compute_expected_tool_name(meta) == "alpha"
+
+    def test_four_survivors_returns_none(self):
+        meta = {"survivor_count": 4, "survivor_names_sorted": ["a", "b", "c", "d"]}
         assert _compute_expected_tool_name(meta) is None
 
     def test_zero_survivors_returns_none(self):
@@ -186,6 +195,11 @@ class TestComputeExpectedToolName:
     def test_survivor_count_mismatch_with_list(self):
         # count says 1 but list is empty → return None (defensive)
         meta = {"survivor_count": 1, "survivor_names_sorted": []}
+        assert _compute_expected_tool_name(meta) is None
+
+    def test_count_mismatch_above_k_returns_none(self):
+        # count says 2 but list has 4 entries → trust count, return None
+        meta = {"survivor_count": 4, "survivor_names_sorted": ["a", "b", "c", "d"]}
         assert _compute_expected_tool_name(meta) is None
 
 
@@ -225,9 +239,10 @@ class TestFirstToolCorrect:
         assert rec["first_tool_correct"] is None
 
     def test_none_when_expected_is_null(self, tmp_path, monkeypatch):
+        # TCP-IMP-16: threshold is k=3; survivor_count > 3 means no expectation.
         log = tmp_path / "decisions.jsonl"
         monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
-        meta = {"survivor_count": 2, "survivor_names_sorted": ["a", "b"]}
+        meta = {"survivor_count": 4, "survivor_names_sorted": ["a", "b", "c", "d"]}
         _write_decision_record(time.time(), meta, "a")
         rec = self._read_last_record(log)
         assert rec["first_tool_correct"] is None


### PR DESCRIPTION
## Summary

- `_compute_expected_tool_name` previously required `survivor_count == 1`, which is structurally unreachable in live shadow sessions (median ~172 survivors per request), making `first_tool_correct` permanently null in `decisions.jsonl`
- Raise threshold to `k=3` (`_EXPECTED_TOOL_MAX_SURVIVORS`) so the proxy emits `expected_tool_name` on turns where filtering narrows to a small shortlist
- No architecture change — scoped entirely to the response tap logic in `cc_proxy.py`

## Kill condition

If `survivor_count ≤ 3` occurs on fewer than 5% of proxied turns in a 4-hour live window, the threshold is still too tight and a different approach (e.g. task-match ranking) is needed.

## Test plan

- [ ] `test_two_survivors_returns_first_survivor` — 2 survivors now emits first name
- [ ] `test_three_survivors_returns_first_survivor` — 3 survivors emits first name  
- [ ] `test_four_survivors_returns_none` — above threshold still returns None
- [ ] `test_none_when_expected_is_null` updated to use `survivor_count: 4`
- [ ] All 39 unit tests pass; pre-existing `test_env_override_allowed_servers` failure unchanged

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)