### PR TITLE
feat(proxy): prompt-similarity ranking for expected_tool_name (TCP-IMP-17)

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -646,6 +646,16 @@ def _process_tools_array(
                 if rec is not None and rec.tool_name in active_survivors
             ]
         ),
+        # TCP-IMP-17: prompt-similarity ranking — top survivor regardless of count.
+        # Populated when the task prompt is non-empty and any survivors exist.
+        "top_survivor_by_similarity": _top_survivor_by_prompt_similarity(
+            prompt,
+            [
+                orig
+                for (orig, rec, _tier, _name) in entries
+                if rec is not None and rec.tool_name in active_survivors
+            ],
+        ),
     }
 
     # ── Empty-set guardrail ──────────────────────────────────────────────
@@ -691,20 +701,55 @@ def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
 # ── Response tap helpers ───────────────────────────────────────────────────────
 
 
-_EXPECTED_TOOL_MAX_SURVIVORS: int = 3  # TCP-IMP-16: emit when survivor_count ≤ k
+_EXPECTED_TOOL_MAX_SURVIVORS: int = 3  # TCP-IMP-16: count-based fallback threshold
+
+
+def _top_survivor_by_prompt_similarity(
+    prompt: str | None,
+    tools: list[Any],
+) -> str | None:
+    """Return the survivor tool name with the highest prompt similarity.
+
+    Computes SequenceMatcher ratio between the task prompt and each tool's
+    ``name + description`` text, returning the argmax.  Returns None when
+    prompt is empty/None or tools list is empty.
+
+    TCP-IMP-17: produces expected_tool_name on every turn with a non-empty
+    prompt, regardless of survivor_count.
+    """
+    if not prompt or not tools:
+        return None
+    prompt_lc = prompt.lower()
+    best_name: str | None = None
+    best_score = -1.0
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            continue
+        name = tool.get("name", "") or ""
+        desc = tool.get("description", "") or ""
+        candidate = f"{name} {desc}".lower()
+        score = difflib.SequenceMatcher(None, prompt_lc, candidate).ratio()
+        if score > best_score:
+            best_score = score
+            best_name = name if isinstance(name, str) else None
+    return best_name
 
 
 def _compute_expected_tool_name(meta: dict[str, Any] | None) -> str | None:
     """Derive expected first tool from request-side survivor metadata.
 
-    Rules (TCP-IMP-16, k=3):
-      - 1 ≤ survivor_count ≤ k  → first sorted survivor name is the expectation
-      - survivor_count > k       → shortlist too broad; return None
-      - survivor_count == 0      → nothing filtered in; return None
-      - otherwise                → return None
+    Priority (TCP-IMP-17):
+      1. top_survivor_by_similarity  → prompt-ranked expectation (all survivor counts)
+      2. count-based fallback (k=3)  → first sorted survivor when count ≤ k
+      3. None                        → no expectation derivable
     """
     if not meta:
         return None
+    # TCP-IMP-17: similarity ranking covers the high-survivor-count majority
+    top_by_sim = meta.get("top_survivor_by_similarity")
+    if top_by_sim is not None:
+        return top_by_sim if isinstance(top_by_sim, str) else None
+    # TCP-IMP-16: count-based fallback for tight shortlists
     count = meta.get("survivor_count", 0)
     survivors = meta.get("survivor_names_sorted", [])
     if 1 <= count <= _EXPECTED_TOOL_MAX_SURVIVORS and len(survivors) >= 1:

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -20,6 +20,7 @@ from tcp.proxy.cc_proxy import (
     _compute_expected_tool_name,
     _first_tool_from_response_body,
     _first_tool_from_sse_buf,
+    _top_survivor_by_prompt_similarity,
     _write_decision_record,
 )
 
@@ -201,6 +202,73 @@ class TestComputeExpectedToolName:
         # count says 2 but list has 4 entries → trust count, return None
         meta = {"survivor_count": 4, "survivor_names_sorted": ["a", "b", "c", "d"]}
         assert _compute_expected_tool_name(meta) is None
+
+    # TCP-IMP-17: top_survivor_by_similarity overrides count-based logic
+    def test_top_survivor_by_similarity_used_when_present(self):
+        """With 174 survivors, expected_tool_name comes from similarity ranking."""
+        meta = {
+            "survivor_count": 174,
+            "survivor_names_sorted": ["Bash", "Read", "Write"],
+            "top_survivor_by_similarity": "Bash",
+        }
+        assert _compute_expected_tool_name(meta) == "Bash"
+
+    def test_top_survivor_by_similarity_overrides_count_k(self):
+        """similarity field takes precedence over k=3 alphabetical pick."""
+        meta = {
+            "survivor_count": 2,
+            "survivor_names_sorted": ["alpha", "zeta"],
+            "top_survivor_by_similarity": "zeta",
+        }
+        assert _compute_expected_tool_name(meta) == "zeta"
+
+    def test_falls_back_to_count_logic_when_similarity_absent(self):
+        """No top_survivor_by_similarity → fall back to k=3 count logic."""
+        meta = {"survivor_count": 2, "survivor_names_sorted": ["tool_a", "tool_b"]}
+        assert _compute_expected_tool_name(meta) == "tool_a"
+
+
+# ── Tests: _top_survivor_by_prompt_similarity ─────────────────────────────────
+
+
+class TestTopSurvivorByPromptSimilarity:
+    def _tool(self, name: str, description: str) -> dict:
+        return {"name": name, "description": description}
+
+    def test_returns_best_matching_tool(self):
+        tools = [
+            self._tool("Bash", "Execute shell commands"),
+            self._tool("Read", "Read file contents from disk"),
+            self._tool("mcp__git__git_status", "Show working tree git status"),
+        ]
+        # Prompt about reading a file → Read should win
+        result = _top_survivor_by_prompt_similarity("read the file contents", tools)
+        assert result == "Read"
+
+    def test_returns_none_for_empty_tools(self):
+        assert _top_survivor_by_prompt_similarity("do something", []) is None
+
+    def test_returns_none_for_empty_prompt(self):
+        tools = [self._tool("Bash", "Execute shell commands")]
+        assert _top_survivor_by_prompt_similarity("", tools) is None
+
+    def test_returns_none_for_none_prompt(self):
+        tools = [self._tool("Bash", "Execute shell commands")]
+        assert _top_survivor_by_prompt_similarity(None, tools) is None  # type: ignore[arg-type]
+
+    def test_single_tool_always_wins(self):
+        tools = [self._tool("OnlyTool", "Does the only thing")]
+        result = _top_survivor_by_prompt_similarity("anything at all", tools)
+        assert result == "OnlyTool"
+
+    def test_git_prompt_favours_git_tool(self):
+        tools = [
+            self._tool("Read", "Read file from disk"),
+            self._tool("mcp__git__git_status", "Show git working tree status"),
+            self._tool("Bash", "Run shell commands"),
+        ]
+        result = _top_survivor_by_prompt_similarity("show git status of working tree", tools)
+        assert result == "mcp__git__git_status"
 
 
 # ── Tests: first_tool_correct computation ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- TCP-MT-16 found that IMP-16's `survivor_count ≤ 3` threshold fired on only **3.53%** of turns (kill condition: <5%), making MT-12 aggregate metrics unmeasurable
- Root cause: median survivor_count ~174 in shadow mode; the k=3 window is structurally unreachable on most turns
- IMP-17 adds `_top_survivor_by_prompt_similarity` which ranks all active survivors by `SequenceMatcher(prompt, name + description)` ratio and stores the winner as `top_survivor_by_similarity` in meta
- `_compute_expected_tool_name` now reads `top_survivor_by_similarity` first (all survivor counts), falling back to the k=3 count logic for tight shortlists

## Expected impact

`expected_tool_name` population rate rises from ~3.5% → ~100% of turns with non-empty prompts, unblocking TCP-MT-17 aggregate measurement.

## Test plan

- [ ] `TestTopSurvivorByPromptSimilarity` — 6 cases: best match, empty tools, empty/None prompt, single tool, git-specific prompt
- [ ] `TestComputeExpectedToolName` — 3 new cases: similarity field used with 174 survivors, overrides alphabetical k=3 pick, falls back when field absent
- [ ] All 45 unit tests pass; pre-existing `test_env_override_allowed_servers` failure unchanged

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)