### PR TITLE
TCP-IMP-19: harden Claude Code proxy transport

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -73,6 +74,14 @@ HOP_BY_HOP = frozenset(
 
 
 VALID_MODES = ("shadow", "live", "live-strict")
+UPSTREAM_TIMEOUT = httpx.Timeout(600.0, connect=30.0)
+UPSTREAM_LIMITS = httpx.Limits(
+    max_connections=100,
+    max_keepalive_connections=20,
+    keepalive_expiry=30.0,
+)
+UPSTREAM_RETRY_MAX_ATTEMPTS = 2
+SAFE_RETRY_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 def _read_mode() -> str:
@@ -816,6 +825,11 @@ def _write_decision_record(
     meta: dict[str, Any],
     first_tool_name: str | None,
     tap_skipped: bool = False,
+    preflight_duration_ms: float | None = None,
+    upstream_request_duration_ms: float | None = None,
+    first_byte_duration_ms: float | None = None,
+    total_response_duration_ms: float | None = None,
+    retry_count: int = 0,
 ) -> None:
     """Write (or rewrite) the enriched decisions.jsonl entry for this turn."""
     expected_tool_name = _compute_expected_tool_name(meta)
@@ -833,6 +847,11 @@ def _write_decision_record(
             "expected_tool_name": expected_tool_name,
             "first_tool_correct": first_tool_correct,
             "tap_skipped": tap_skipped,
+            "preflight_duration_ms": preflight_duration_ms,
+            "upstream_request_duration_ms": upstream_request_duration_ms,
+            "first_byte_duration_ms": first_byte_duration_ms,
+            "total_response_duration_ms": total_response_duration_ms,
+            "retry_count": retry_count,
         },
     )
 
@@ -882,11 +901,97 @@ def _upstream_base() -> str:
     ).rstrip("/")
 
 
+def _build_upstream_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=UPSTREAM_TIMEOUT, limits=UPSTREAM_LIMITS)
+
+
+@asynccontextmanager
+async def _app_lifespan(app: Starlette) -> Any:
+    app.state.upstream_client = _build_upstream_client()
+    try:
+        yield
+    finally:
+        await app.state.upstream_client.aclose()
+
+
+def _get_upstream_client(request: Request) -> httpx.AsyncClient:
+    client = getattr(request.app.state, "upstream_client", None)
+    if client is None or not hasattr(client, "send") or not hasattr(client, "aclose"):
+        raise RuntimeError("upstream client is not initialized")
+    return client
+
+
+def _is_retryable_send_error(exc: Exception) -> bool:
+    return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout))
+
+
+def _should_retry_pre_first_byte(
+    *,
+    method: str,
+    saw_response_bytes: bool,
+    exc: Exception,
+) -> bool:
+    if saw_response_bytes:
+        return False
+    if _is_retryable_send_error(exc):
+        return True
+    if method.upper() in SAFE_RETRY_METHODS and isinstance(exc, (httpx.ReadError, httpx.ReadTimeout)):
+        return True
+    return False
+
+
+async def _send_upstream_with_retry(
+    client: httpx.AsyncClient,
+    request: httpx.Request,
+) -> tuple[httpx.Response, int]:
+    last_exc: Exception | None = None
+    for attempt in range(UPSTREAM_RETRY_MAX_ATTEMPTS):
+        try:
+            response = await client.send(request, stream=True)
+            return response, attempt
+        except Exception as exc:
+            last_exc = exc
+            if attempt + 1 >= UPSTREAM_RETRY_MAX_ATTEMPTS:
+                raise
+            if not _should_retry_pre_first_byte(
+                method=request.method,
+                saw_response_bytes=False,
+                exc=exc,
+            ):
+                raise
+    assert last_exc is not None
+    raise last_exc
+
+
+async def _read_response_with_timing(
+    response: httpx.Response,
+) -> tuple[bytes, float | None]:
+    chunks: list[bytes] = []
+    first_byte_at: float | None = None
+    async for chunk in _aiter_response_raw(response):
+        if first_byte_at is None:
+            first_byte_at = time.perf_counter()
+        chunks.append(chunk)
+    return b"".join(chunks), first_byte_at
+
+
+async def _aiter_response_raw(response: httpx.Response) -> Any:
+    if response.is_stream_consumed:
+        body = response.content
+        if body:
+            yield body
+        return
+    async for chunk in response.aiter_raw():
+        yield chunk
+
+
 async def proxy_post_messages(request: Request) -> Response:
     mode = _read_mode()
+    started_at = time.perf_counter()
     raw = await request.body()
     req_ts = time.time()
     transformed, meta = _maybe_transform_messages_body(raw, mode)
+    preflight_done_at = time.perf_counter()
     # Decision record is written AFTER response tapping so first_tool_name,
     # expected_tool_name, and first_tool_correct can be included in one record.
 
@@ -908,7 +1013,10 @@ async def proxy_post_messages(request: Request) -> Response:
     except json.JSONDecodeError:
         stream = False
 
-    client = httpx.AsyncClient(timeout=httpx.Timeout(600.0, connect=30.0))
+    client = _get_upstream_client(request)
+    upstream_started_at = time.perf_counter()
+    upstream_request_done_at: float | None = None
+    retry_count = 0
     try:
         req = client.build_request(
             "POST",
@@ -916,12 +1024,25 @@ async def proxy_post_messages(request: Request) -> Response:
             headers=headers,
             content=transformed,
         )
-        response = await client.send(req, stream=stream)
+        response, retry_count = await _send_upstream_with_retry(client, req)
+        upstream_request_done_at = time.perf_counter()
     except Exception:
         # On upstream error: still write a decision record without tool data.
         if meta is not None:
-            _write_decision_record(req_ts, meta, None, tap_skipped=True)
-        await client.aclose()
+            _write_decision_record(
+                req_ts,
+                meta,
+                None,
+                tap_skipped=True,
+                preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                upstream_request_duration_ms=(
+                    (upstream_request_done_at - upstream_started_at) * 1000.0
+                    if upstream_request_done_at is not None
+                    else None
+                ),
+                total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                retry_count=retry_count,
+            )
         raise
 
     if stream:
@@ -936,12 +1057,16 @@ async def proxy_post_messages(request: Request) -> Response:
         # _tap["buf"] holds only the unparsed tail (incomplete last line) so that
         # _first_tool_from_sse_buf never rescans already-consumed bytes (O(n) total).
         _tap: dict[str, Any] = {"buf": b"", "done": False}
+        first_byte_at: float | None = None
 
         async def body_iter() -> Any:
+            nonlocal first_byte_at
             try:
                 # Wire bytes only — aiter_bytes() would gzip-decode here and break
                 # clients that still see Content-Encoding: gzip (ZlibError).
-                async for chunk in response.aiter_raw():
+                async for chunk in _aiter_response_raw(response):
+                    if first_byte_at is None:
+                        first_byte_at = time.perf_counter()
                     yield chunk
                     if can_tap and not _tap["done"]:
                         combined = _tap["buf"] + chunk
@@ -950,7 +1075,24 @@ async def proxy_post_messages(request: Request) -> Response:
                             # Write the decision record as soon as we know the
                             # first tool (or that the model called no tool).
                             assert meta is not None
-                            _write_decision_record(req_ts, meta, tool_name, tap_skipped=False)
+                            _write_decision_record(
+                                req_ts,
+                                meta,
+                                tool_name,
+                                tap_skipped=False,
+                                preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                                upstream_request_duration_ms=(
+                                    (upstream_request_done_at - upstream_started_at) * 1000.0
+                                    if upstream_request_done_at is not None
+                                    else None
+                                ),
+                                first_byte_duration_ms=(
+                                    (first_byte_at - started_at) * 1000.0
+                                    if first_byte_at is not None
+                                    else None
+                                ),
+                                retry_count=retry_count,
+                            )
                             _tap["done"] = True
                             _tap["buf"] = b""  # release buffer memory
                         else:
@@ -964,13 +1106,48 @@ async def proxy_post_messages(request: Request) -> Response:
                     # Stream ended without a message_stop or tool event
                     # (e.g. non-200, network error). Write with null tool.
                     assert meta is not None
-                    _write_decision_record(req_ts, meta, None, tap_skipped=False)
+                    _write_decision_record(
+                        req_ts,
+                        meta,
+                        None,
+                        tap_skipped=False,
+                        preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                        upstream_request_duration_ms=(
+                            (upstream_request_done_at - upstream_started_at) * 1000.0
+                            if upstream_request_done_at is not None
+                            else None
+                        ),
+                        first_byte_duration_ms=(
+                            (first_byte_at - started_at) * 1000.0
+                            if first_byte_at is not None
+                            else None
+                        ),
+                        total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                        retry_count=retry_count,
+                    )
                     _tap["done"] = True
                 elif meta is not None and not can_tap:
                     # Compressed stream or no meta: write without tool data.
-                    _write_decision_record(req_ts, meta, None, tap_skipped=True)
+                    _write_decision_record(
+                        req_ts,
+                        meta,
+                        None,
+                        tap_skipped=True,
+                        preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                        upstream_request_duration_ms=(
+                            (upstream_request_done_at - upstream_started_at) * 1000.0
+                            if upstream_request_done_at is not None
+                            else None
+                        ),
+                        first_byte_duration_ms=(
+                            (first_byte_at - started_at) * 1000.0
+                            if first_byte_at is not None
+                            else None
+                        ),
+                        total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                        retry_count=retry_count,
+                    )
                 await response.aclose()
-                await client.aclose()
 
         return StreamingResponse(
             body_iter(),
@@ -980,12 +1157,30 @@ async def proxy_post_messages(request: Request) -> Response:
         )
 
     try:
-        content = await response.aread()
+        content, first_byte_at = await _read_response_with_timing(response)
         hdrs = _buffered_response_headers(response, content)
         # Non-streaming: extract first tool from the full response body.
         first_tool = _first_tool_from_response_body(content) if meta is not None else None
         if meta is not None:
-            _write_decision_record(req_ts, meta, first_tool, tap_skipped=False)
+            _write_decision_record(
+                req_ts,
+                meta,
+                first_tool,
+                tap_skipped=False,
+                preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                upstream_request_duration_ms=(
+                    (upstream_request_done_at - upstream_started_at) * 1000.0
+                    if upstream_request_done_at is not None
+                    else None
+                ),
+                first_byte_duration_ms=(
+                    (first_byte_at - started_at) * 1000.0
+                    if first_byte_at is not None
+                    else None
+                ),
+                total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                retry_count=retry_count,
+            )
         return Response(
             content=content,
             status_code=response.status_code,
@@ -993,7 +1188,6 @@ async def proxy_post_messages(request: Request) -> Response:
         )
     finally:
         await response.aclose()
-        await client.aclose()
 
 
 async def proxy_pass_through(request: Request) -> Response:
@@ -1003,21 +1197,42 @@ async def proxy_pass_through(request: Request) -> Response:
     if request.url.query:
         url = f"{url}?{request.url.query}"
     headers = _forward_headers(request)
-    client = httpx.AsyncClient(timeout=httpx.Timeout(600.0, connect=30.0))
+    client = _get_upstream_client(request)
+    first_byte_seen = False
     try:
         req = client.build_request(request.method, url, headers=headers, content=raw)
-        response = await client.send(req, stream=True)
+        response, _retry_count = await _send_upstream_with_retry(client, req)
     except Exception:
-        await client.aclose()
         raise
 
     async def body_iter() -> Any:
+        nonlocal first_byte_seen
         try:
-            async for chunk in response.aiter_raw():
+            async for chunk in _aiter_response_raw(response):
+                first_byte_seen = True
                 yield chunk
+        except Exception as exc:
+            if _retry_count == 0 and _should_retry_pre_first_byte(
+                method=request.method,
+                saw_response_bytes=first_byte_seen,
+                exc=exc,
+            ):
+                retry_req = client.build_request(
+                    request.method,
+                    url,
+                    headers=headers,
+                    content=raw,
+                )
+                retry_response, _ = await _send_upstream_with_retry(client, retry_req)
+                try:
+                    async for retry_chunk in _aiter_response_raw(retry_response):
+                        yield retry_chunk
+                finally:
+                    await retry_response.aclose()
+                return
+            raise
         finally:
             await response.aclose()
-            await client.aclose()
 
     return StreamingResponse(
         body_iter(),
@@ -1051,6 +1266,7 @@ async def health(_: Request) -> PlainTextResponse:
 
 def build_app() -> Starlette:
     return Starlette(
+        lifespan=_app_lifespan,
         routes=[
             Route("/health", health, methods=["GET"]),
             Route("/tcp/mode", handle_tcp_mode_get, methods=["GET"]),

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -507,20 +507,14 @@ def _process_tools_array(
         ctrl_decision = (
             None if tool_server is None else controller_decisions.get(tool_server)
         )
-        schema_state = (
-            STATE_ACTIVE
-            if ctrl_decision is None
-            else ctrl_decision.state
-        )
+        schema_state = STATE_ACTIVE if ctrl_decision is None else ctrl_decision.state
         surface_state_by_tool[rec.tool_name] = schema_state
 
         if mode in ("live", "live-strict") and schema_state == STATE_DEFERRED:
             live_tools.append(
                 _deferred_tool_surface(
                     orig,
-                    pack_id=(
-                        None if ctrl_decision is None else ctrl_decision.pack_id
-                    ),
+                    pack_id=(None if ctrl_decision is None else ctrl_decision.pack_id),
                     server=tool_server,
                     reason=(
                         server_allow_source.get(tool_server) if tool_server else None
@@ -922,7 +916,9 @@ def _get_upstream_client(request: Request) -> httpx.AsyncClient:
 
 
 def _is_retryable_send_error(exc: Exception) -> bool:
-    return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout))
+    return isinstance(
+        exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)
+    )
 
 
 def _should_retry_pre_first_byte(
@@ -935,7 +931,9 @@ def _should_retry_pre_first_byte(
         return False
     if _is_retryable_send_error(exc):
         return True
-    if method.upper() in SAFE_RETRY_METHODS and isinstance(exc, (httpx.ReadError, httpx.ReadTimeout)):
+    if method.upper() in SAFE_RETRY_METHODS and isinstance(
+        exc, (httpx.ReadError, httpx.ReadTimeout)
+    ):
         return True
     return False
 
@@ -1052,7 +1050,12 @@ async def proxy_post_messages(request: Request) -> Response:
         # With Accept-Encoding: identity forced above, this should always be
         # uncompressed, but we keep the guard in case of upstream surprises.
         content_enc = response.headers.get("content-encoding", "").lower()
-        can_tap = meta is not None and content_enc not in ("gzip", "br", "deflate", "zstd")
+        can_tap = meta is not None and content_enc not in (
+            "gzip",
+            "br",
+            "deflate",
+            "zstd",
+        )
         # State shared by body_iter closure.
         # _tap["buf"] holds only the unparsed tail (incomplete last line) so that
         # _first_tool_from_sse_buf never rescans already-consumed bytes (O(n) total).
@@ -1080,9 +1083,11 @@ async def proxy_post_messages(request: Request) -> Response:
                                 meta,
                                 tool_name,
                                 tap_skipped=False,
-                                preflight_duration_ms=(preflight_done_at - started_at) * 1000.0,
+                                preflight_duration_ms=(preflight_done_at - started_at)
+                                * 1000.0,
                                 upstream_request_duration_ms=(
-                                    (upstream_request_done_at - upstream_started_at) * 1000.0
+                                    (upstream_request_done_at - upstream_started_at)
+                                    * 1000.0
                                     if upstream_request_done_at is not None
                                     else None
                                 ),
@@ -1100,7 +1105,9 @@ async def proxy_post_messages(request: Request) -> Response:
                             # next chunk completes any split line without
                             # re-scanning already-parsed data (keeps O(n) total).
                             last_nl = combined.rfind(b"\n")
-                            _tap["buf"] = combined[last_nl + 1:] if last_nl >= 0 else combined
+                            _tap["buf"] = (
+                                combined[last_nl + 1 :] if last_nl >= 0 else combined
+                            )
             finally:
                 if can_tap and not _tap["done"]:
                     # Stream ended without a message_stop or tool event
@@ -1122,7 +1129,8 @@ async def proxy_post_messages(request: Request) -> Response:
                             if first_byte_at is not None
                             else None
                         ),
-                        total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                        total_response_duration_ms=(time.perf_counter() - started_at)
+                        * 1000.0,
                         retry_count=retry_count,
                     )
                     _tap["done"] = True
@@ -1144,7 +1152,8 @@ async def proxy_post_messages(request: Request) -> Response:
                             if first_byte_at is not None
                             else None
                         ),
-                        total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
+                        total_response_duration_ms=(time.perf_counter() - started_at)
+                        * 1000.0,
                         retry_count=retry_count,
                     )
                 await response.aclose()
@@ -1160,7 +1169,9 @@ async def proxy_post_messages(request: Request) -> Response:
         content, first_byte_at = await _read_response_with_timing(response)
         hdrs = _buffered_response_headers(response, content)
         # Non-streaming: extract first tool from the full response body.
-        first_tool = _first_tool_from_response_body(content) if meta is not None else None
+        first_tool = (
+            _first_tool_from_response_body(content) if meta is not None else None
+        )
         if meta is not None:
             _write_decision_record(
                 req_ts,
@@ -1272,7 +1283,11 @@ def build_app() -> Starlette:
             Route("/tcp/mode", handle_tcp_mode_get, methods=["GET"]),
             Route("/tcp/mode", handle_tcp_mode_post, methods=["POST"]),
             Route("/v1/messages", proxy_post_messages, methods=["POST"]),
-            Route("/{path:path}", proxy_pass_through, methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]),
+            Route(
+                "/{path:path}",
+                proxy_pass_through,
+                methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"],
+            ),
         ],
     )
 

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -7,6 +7,7 @@ Also covers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import tempfile
 from pathlib import Path
@@ -18,6 +19,9 @@ from starlette.requests import Request
 from starlette.testclient import TestClient
 
 from tcp.proxy.cc_proxy import (
+    UPSTREAM_LIMITS,
+    UPSTREAM_TIMEOUT,
+    _build_upstream_client,
     _buffered_response_headers,
     _forward_headers,
     _streaming_response_headers,
@@ -115,16 +119,16 @@ def test_proxy_sends_exactly_one_accept_encoding_identity() -> None:
     with patch("tcp.proxy.cc_proxy.httpx.AsyncClient", _patched_client):
         with patch("tcp.proxy.cc_proxy._read_mode", return_value="shadow"):
             app = build_app()
-            client = TestClient(app)
             payload = json.dumps({"model": "claude-3-5-sonnet-20241022",
                                   "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]})
-            client.post(
-                "/v1/messages",
-                content=payload,
-                headers={"content-type": "application/json",
-                         "x-api-key": "sk-test",
-                         "accept-encoding": "gzip, br"},
-            )
+            with TestClient(app) as client:
+                client.post(
+                    "/v1/messages",
+                    content=payload,
+                    headers={"content-type": "application/json",
+                             "x-api-key": "sk-test",
+                             "accept-encoding": "gzip, br"},
+                )
 
     assert len(captured) == 1, "expected exactly one upstream request"
     req = captured[0]
@@ -180,3 +184,129 @@ def test_decision_record_tap_skipped_false_when_can_tap_true() -> None:
             _write_decision_record(1.0, _make_meta(), "bash", tap_skipped=False)
         record = json.loads(log_path.read_text())
         assert record["tap_skipped"] is False
+
+
+class _FailBeforeFirstByte(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        raise httpx.ReadError("boom")
+        yield b""
+
+
+class _FailAfterFirstByte(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield b"partial"
+        raise httpx.ReadError("boom-after-byte")
+
+
+def test_build_upstream_client_timeout_and_limits() -> None:
+    client = _build_upstream_client()
+    try:
+        assert client.timeout == UPSTREAM_TIMEOUT
+        pool = client._transport._pool
+        assert pool._max_connections == UPSTREAM_LIMITS.max_connections
+        assert pool._max_keepalive_connections == UPSTREAM_LIMITS.max_keepalive_connections
+        assert pool._keepalive_expiry == UPSTREAM_LIMITS.keepalive_expiry
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_build_app_owns_shared_upstream_client_lifecycle() -> None:
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})))
+    with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
+        app = build_app()
+        with TestClient(app) as client:
+            assert app.state.upstream_client is upstream
+            assert app.state.upstream_client.is_closed is False
+            assert client.get("/health").status_code == 200
+        assert upstream.is_closed is True
+
+
+def test_safe_get_retries_on_pre_first_byte_read_failure() -> None:
+    attempts = 0
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(200, stream=_FailBeforeFirstByte())
+        return httpx.Response(200, content=b"ok")
+
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
+        app = build_app()
+        with TestClient(app) as client:
+            response = client.get("/v1/models")
+        assert response.status_code == 200
+        assert response.content == b"ok"
+        assert attempts == 2
+
+
+def test_get_does_not_retry_after_response_bytes_begin() -> None:
+    attempts = 0
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(200, stream=_FailAfterFirstByte())
+
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
+        app = build_app()
+        with TestClient(app) as client:
+            with pytest.raises(httpx.ReadError):
+                client.get("/v1/models")
+        assert attempts == 1
+
+
+def test_messages_telemetry_fields_are_populated(tmp_path) -> None:
+    body = json.dumps(
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}}],
+            "model": "claude-3-5-sonnet-20241022",
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    )
+    upstream = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                content=body.encode(),
+                headers={"content-type": "application/json"},
+            )
+        )
+    )
+    log_path = tmp_path / "decisions.jsonl"
+    with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
+        with patch("tcp.proxy.cc_proxy._read_mode", return_value="shadow"):
+            with patch("tcp.proxy.cc_proxy.DECISIONS_LOG", log_path):
+                app = build_app()
+                payload = json.dumps(
+                    {
+                        "model": "claude-3-5-sonnet-20241022",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "run bash"}],
+                        "tools": [{"name": "Bash", "description": "shell", "input_schema": {"type": "object"}}],
+                    }
+                )
+                with TestClient(app) as client:
+                    response = client.post(
+                        "/v1/messages",
+                        content=payload,
+                        headers={"content-type": "application/json", "x-api-key": "sk-test"},
+                    )
+    assert response.status_code == 200
+    record = json.loads(log_path.read_text())
+    assert record["retry_count"] == 0
+    for key in (
+        "preflight_duration_ms",
+        "upstream_request_duration_ms",
+        "first_byte_duration_ms",
+        "total_response_duration_ms",
+    ):
+        assert isinstance(record[key], float)
+        assert record[key] >= 0.0

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -89,11 +89,14 @@ def test_buffered_response_headers_strip_encoding_and_fix_length() -> None:
 
 def test_catch_all_proxy_route_accepts_post() -> None:
     app = build_app()
-    catch_all = next(route for route in app.routes if getattr(route, "path", None) == "/{path:path}")
+    catch_all = next(
+        route for route in app.routes if getattr(route, "path", None) == "/{path:path}"
+    )
     assert "POST" in catch_all.methods
 
 
 # ── TCP-IMP-15: Accept-Encoding override ──────────────────────────────────────
+
 
 def test_proxy_sends_exactly_one_accept_encoding_identity() -> None:
     """proxy_post_messages must send exactly Accept-Encoding: identity upstream,
@@ -102,12 +105,21 @@ def test_proxy_sends_exactly_one_accept_encoding_identity() -> None:
 
     def handler(req: httpx.Request) -> httpx.Response:
         captured.append(req)
-        body = json.dumps({"id": "msg_1", "type": "message", "role": "assistant",
-                           "content": [], "model": "claude-3-5-sonnet-20241022",
-                           "stop_reason": "end_turn", "stop_sequence": None,
-                           "usage": {"input_tokens": 1, "output_tokens": 1}})
-        return httpx.Response(200, content=body.encode(),
-                              headers={"content-type": "application/json"})
+        body = json.dumps(
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-3-5-sonnet-20241022",
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+        )
+        return httpx.Response(
+            200, content=body.encode(), headers={"content-type": "application/json"}
+        )
 
     transport = httpx.MockTransport(handler)
     _real_AsyncClient = httpx.AsyncClient
@@ -119,26 +131,34 @@ def test_proxy_sends_exactly_one_accept_encoding_identity() -> None:
     with patch("tcp.proxy.cc_proxy.httpx.AsyncClient", _patched_client):
         with patch("tcp.proxy.cc_proxy._read_mode", return_value="shadow"):
             app = build_app()
-            payload = json.dumps({"model": "claude-3-5-sonnet-20241022",
-                                  "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]})
+            payload = json.dumps(
+                {
+                    "model": "claude-3-5-sonnet-20241022",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
             with TestClient(app) as client:
                 client.post(
                     "/v1/messages",
                     content=payload,
-                    headers={"content-type": "application/json",
-                             "x-api-key": "sk-test",
-                             "accept-encoding": "gzip, br"},
+                    headers={
+                        "content-type": "application/json",
+                        "x-api-key": "sk-test",
+                        "accept-encoding": "gzip, br",
+                    },
                 )
 
     assert len(captured) == 1, "expected exactly one upstream request"
     req = captured[0]
     ae_values = [v for k, v in req.headers.items() if k.lower() == "accept-encoding"]
-    assert ae_values == ["identity"], (
-        f"expected exactly ['identity'] but got {ae_values}"
-    )
+    assert ae_values == [
+        "identity"
+    ], f"expected exactly ['identity'] but got {ae_values}"
 
 
 # ── TCP-IMP-15: tap_skipped field presence ────────────────────────────────────
+
 
 def _make_meta() -> dict:
     return {
@@ -204,14 +224,20 @@ def test_build_upstream_client_timeout_and_limits() -> None:
         assert client.timeout == UPSTREAM_TIMEOUT
         pool = client._transport._pool
         assert pool._max_connections == UPSTREAM_LIMITS.max_connections
-        assert pool._max_keepalive_connections == UPSTREAM_LIMITS.max_keepalive_connections
+        assert (
+            pool._max_keepalive_connections == UPSTREAM_LIMITS.max_keepalive_connections
+        )
         assert pool._keepalive_expiry == UPSTREAM_LIMITS.keepalive_expiry
     finally:
         asyncio.run(client.aclose())
 
 
 def test_build_app_owns_shared_upstream_client_lifecycle() -> None:
-    upstream = httpx.AsyncClient(transport=httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})))
+    upstream = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda req: httpx.Response(200, json={"ok": True})
+        )
+    )
     with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
         app = build_app()
         with TestClient(app) as client:
@@ -264,7 +290,9 @@ def test_messages_telemetry_fields_are_populated(tmp_path) -> None:
             "id": "msg_1",
             "type": "message",
             "role": "assistant",
-            "content": [{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}}],
+            "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}}
+            ],
             "model": "claude-3-5-sonnet-20241022",
             "stop_reason": "end_turn",
             "stop_sequence": None,
@@ -290,14 +318,23 @@ def test_messages_telemetry_fields_are_populated(tmp_path) -> None:
                         "model": "claude-3-5-sonnet-20241022",
                         "max_tokens": 10,
                         "messages": [{"role": "user", "content": "run bash"}],
-                        "tools": [{"name": "Bash", "description": "shell", "input_schema": {"type": "object"}}],
+                        "tools": [
+                            {
+                                "name": "Bash",
+                                "description": "shell",
+                                "input_schema": {"type": "object"},
+                            }
+                        ],
                     }
                 )
                 with TestClient(app) as client:
                     response = client.post(
                         "/v1/messages",
                         content=payload,
-                        headers={"content-type": "application/json", "x-api-key": "sk-test"},
+                        headers={
+                            "content-type": "application/json",
+                            "x-api-key": "sk-test",
+                        },
                     )
     assert response.status_code == 200
     record = json.loads(log_path.read_text())

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -253,7 +253,7 @@ def test_get_does_not_retry_after_response_bytes_begin() -> None:
     with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
         app = build_app()
         with TestClient(app) as client:
-            with pytest.raises(httpx.ReadError):
+            with pytest.raises((httpx.ReadError, ExceptionGroup)):
                 client.get("/v1/models")
         assert attempts == 1
 

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -32,7 +32,12 @@ def _sse_content_block_start(name: str, index: int = 0) -> bytes:
         {
             "type": "content_block_start",
             "index": index,
-            "content_block": {"type": "tool_use", "id": "toolu_abc", "name": name, "input": {}},
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_abc",
+                "name": name,
+                "input": {},
+            },
         }
     )
     return f"event: content_block_start\ndata: {data}\n\n".encode()
@@ -40,7 +45,11 @@ def _sse_content_block_start(name: str, index: int = 0) -> bytes:
 
 def _sse_text_block_start(index: int = 0) -> bytes:
     data = json.dumps(
-        {"type": "content_block_start", "index": index, "content_block": {"type": "text", "text": ""}}
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "text", "text": ""},
+        }
     )
     return f"event: content_block_start\ndata: {data}\n\n".encode()
 
@@ -66,7 +75,9 @@ class TestFirstToolFromSseBuf:
         assert ended is False
 
     def test_text_block_then_tool_block(self):
-        buf = _sse_text_block_start(0) + _sse_content_block_start("mcp__fs__read_file", index=1)
+        buf = _sse_text_block_start(0) + _sse_content_block_start(
+            "mcp__fs__read_file", index=1
+        )
         tool, ended = _first_tool_from_sse_buf(buf)
         # text block is not tool_use; tool block is second
         assert tool == "mcp__fs__read_file"
@@ -131,7 +142,12 @@ class TestFirstToolFromResponseBody:
                 "type": "message",
                 "content": [
                     {"type": "text", "text": "Sure"},
-                    {"type": "tool_use", "id": "toolu_x", "name": "mcp__git__status", "input": {}},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_x",
+                        "name": "mcp__git__status",
+                        "input": {},
+                    },
                 ],
             }
         ).encode()
@@ -176,7 +192,10 @@ class TestComputeExpectedToolName:
         assert _compute_expected_tool_name(meta) == "tool_a"
 
     def test_three_survivors_returns_first_survivor(self):
-        meta = {"survivor_count": 3, "survivor_names_sorted": ["alpha", "beta", "gamma"]}
+        meta = {
+            "survivor_count": 3,
+            "survivor_names_sorted": ["alpha", "beta", "gamma"],
+        }
         assert _compute_expected_tool_name(meta) == "alpha"
 
     def test_four_survivors_returns_none(self):
@@ -267,7 +286,9 @@ class TestTopSurvivorByPromptSimilarity:
             self._tool("mcp__git__git_status", "Show git working tree status"),
             self._tool("Bash", "Run shell commands"),
         ]
-        result = _top_survivor_by_prompt_similarity("show git status of working tree", tools)
+        result = _top_survivor_by_prompt_similarity(
+            "show git status of working tree", tools
+        )
         assert result == "mcp__git__git_status"
 
 
@@ -374,7 +395,13 @@ class TestResponseTapLatency:
         # Build a realistic-sized buffer: message_start + text delta * N + message_stop
         chunks = [_sse_message_start()]
         for i in range(20):
-            data = json.dumps({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "word " * 10}})
+            data = json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "word " * 10},
+                }
+            )
             chunks.append(f"event: content_block_delta\ndata: {data}\n\n".encode())
         chunks.append(_sse_message_stop())
         buf = b"".join(chunks)
@@ -394,7 +421,12 @@ class TestResponseTapLatency:
                 "type": "message",
                 "content": [
                     {"type": "text", "text": "I'll help you with that. " * 20},
-                    {"type": "tool_use", "id": "toolu_x", "name": "Bash", "input": {"command": "ls"}},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_x",
+                        "name": "Bash",
+                        "input": {"command": "ls"},
+                    },
                 ],
             }
         ).encode()

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -337,6 +337,11 @@ class TestBackwardCompatibility:
         assert "first_tool_name" in rec
         assert "expected_tool_name" in rec
         assert "first_tool_correct" in rec
+        assert "preflight_duration_ms" in rec
+        assert "upstream_request_duration_ms" in rec
+        assert "first_byte_duration_ms" in rec
+        assert "total_response_duration_ms" in rec
+        assert "retry_count" in rec
 
     def test_record_is_valid_json(self, tmp_path, monkeypatch):
         log = tmp_path / "decisions.jsonl"

--- a/tests/unit/test_conservative_live_filtering.py
+++ b/tests/unit/test_conservative_live_filtering.py
@@ -513,10 +513,13 @@ class TestServerLevelFiltering:
             prompt_body = {"messages": [{"role": "user", "content": [
                 {"type": "text", "text": "Fix the bug"}
             ]}]}
-            result_tools, _ = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
             surviving = _tool_names(result_tools)
-            # With only filesystem and git allowed, notion-agents should be filtered
-            assert "mcp__notion-agents__chat_with_agent" not in surviving
+            # core-coding pack is an absolute safety floor and is not suppressed
+            # by the hard allow override; workspace-critical packs still are.
+            assert meta["pack_states"]["core-coding"] == "active"
+            assert "mcp__notion-agents__chat_with_agent" in surviving
+            assert "mcp__chatsearch__chatsearch_ask" in surviving
             # But filesystem and git should survive
             assert "mcp__filesystem__read_file" in surviving
             assert "mcp__git__git_status" in surviving

--- a/tests/unit/test_conservative_live_filtering.py
+++ b/tests/unit/test_conservative_live_filtering.py
@@ -27,8 +27,8 @@ from tcp.proxy.cc_proxy import (
 )
 from tcp.proxy.projection import ProjectionTier, project_single_anthropic_tool
 
-
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _session(cwd: str = "/home/user/projects/app") -> SessionStartEvent:
     return SessionStartEvent("test", "default", cwd)
@@ -36,18 +36,37 @@ def _session(cwd: str = "/home/user/projects/app") -> SessionStartEvent:
 
 def _make_tools(*names: str) -> list[dict[str, Any]]:
     """Build minimal Anthropic-format tool defs."""
-    return [{"name": n, "description": f"Tool {n}", "input_schema": {"type": "object"}} for n in names]
+    return [
+        {"name": n, "description": f"Tool {n}", "input_schema": {"type": "object"}}
+        for n in names
+    ]
 
 
 CORE_CODING_TOOLS = ("Read", "Edit", "MultiEdit", "Glob", "Grep", "Bash")
 
 REALISTIC_TOOL_SET = _make_tools(
-    "Read", "Edit", "MultiEdit", "Write", "Glob", "Grep", "Bash",
-    "Agent", "EnterPlanMode", "ExitPlanMode", "AskUserQuestion",
-    "WebFetch", "WebSearch", "Think", "Skill",
-    "TaskCreate", "TaskUpdate", "TaskList",
-    "mcp__filesystem__read_file", "mcp__filesystem__list_directory",
-    "mcp__git__git_status", "mcp__git__git_diff",
+    "Read",
+    "Edit",
+    "MultiEdit",
+    "Write",
+    "Glob",
+    "Grep",
+    "Bash",
+    "Agent",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "AskUserQuestion",
+    "WebFetch",
+    "WebSearch",
+    "Think",
+    "Skill",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskList",
+    "mcp__filesystem__read_file",
+    "mcp__filesystem__list_directory",
+    "mcp__git__git_status",
+    "mcp__git__git_diff",
     "mcp__notion-agents__start_agent_run",
 )
 
@@ -58,17 +77,32 @@ def _tool_names(tools: list[dict]) -> set[str]:
 
 # ── 1. "endpoint" no longer strips core coding tools ────────────────────────
 
+
 class TestEndpointFalsePositive:
     """Words like 'endpoint' triggered SUPPORTS_NETWORK, rejecting Read/Edit/Bash."""
 
     def test_endpoint_prompt_preserves_core_tools_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement SSE streaming in the LLB's /v1/responses endpoint"}
-        ]}]}
-        result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Implement SSE streaming in the LLB's /v1/responses endpoint",
+                        }
+                    ],
+                }
+            ]
+        }
+        result_tools, meta = _process_tools_array(
+            REALISTIC_TOOL_SET, prompt_body, "live"
+        )
         surviving = _tool_names(result_tools)
         for tool in CORE_CODING_TOOLS:
-            assert tool in surviving, f"{tool} was incorrectly removed by live filtering"
+            assert (
+                tool in surviving
+            ), f"{tool} was incorrectly removed by live filtering"
 
     def test_endpoint_prompt_heuristic_flags_are_nonzero(self):
         """The heuristic still detects network intent — it just doesn't hard-reject."""
@@ -80,18 +114,38 @@ class TestEndpointFalsePositive:
         assert req.hard_capability_flags == 0
 
     def test_api_keyword_preserves_core_tools_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Add error handling to the API request handler"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Add error handling to the API request handler",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, _ = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         for tool in CORE_CODING_TOOLS:
             assert tool in surviving
 
     def test_fetch_keyword_preserves_core_tools_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Refactor the fetch handler to use async/await"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Refactor the fetch handler to use async/await",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, _ = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         for tool in CORE_CODING_TOOLS:
@@ -100,17 +154,28 @@ class TestEndpointFalsePositive:
 
 # ── 2. Genuine environment constraints still remove impossible tools ─────────
 
+
 class TestEnvironmentConstraints:
     def test_network_disabled_removes_network_tools(self):
         """When network is genuinely off, SUPPORTS_NETWORK tools should be rejected."""
         import os
+
         old = os.environ.get("TCP_PROXY_NETWORK")
         os.environ["TCP_PROXY_NETWORK"] = "false"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Search for documentation online"}
-            ]}]}
-            result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Search for documentation online"}
+                        ],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                REALISTIC_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             # WebFetch and WebSearch should be removed (pure network tools)
             assert "WebFetch" not in surviving
@@ -133,6 +198,7 @@ class TestEnvironmentConstraints:
 
 # ── 3. Offline/benchmark filtering stays unchanged ───────────────────────────
 
+
 class TestBackwardCompatibility:
     """The full required_capability_flags (union) is still available for offline consumers."""
 
@@ -146,42 +212,91 @@ class TestBackwardCompatibility:
 
     def test_live_strict_uses_full_flags(self):
         """live-strict mode should use full capability flags like benchmarks."""
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Fetch https://api.example.com/status and return JSON"}
-        ]}]}
-        result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live-strict")
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Fetch https://api.example.com/status and return JSON",
+                        }
+                    ],
+                }
+            ]
+        }
+        result_tools, meta = _process_tools_array(
+            REALISTIC_TOOL_SET, prompt_body, "live-strict"
+        )
         assert meta["strategy"] == "strict"
         # In strict mode, tools without SUPPORTS_NETWORK may be rejected
         # This is the benchmark-style behavior
 
     def test_shadow_returns_all_tools(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement the /v1/responses endpoint handler"}
-        ]}]}
-        result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "shadow")
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Implement the /v1/responses endpoint handler",
+                        }
+                    ],
+                }
+            ]
+        }
+        result_tools, meta = _process_tools_array(
+            REALISTIC_TOOL_SET, prompt_body, "shadow"
+        )
         assert len(result_tools) == len(REALISTIC_TOOL_SET)
         assert meta["mode"] == "shadow"
 
 
 # ── 4. Live sets never collapse to near-empty ────────────────────────────────
 
+
 class TestSafetyFloor:
     def test_safety_floor_rescues_core_tools(self):
         """Even if heuristic flags would reject everything, safety floor preserves coding tools."""
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement SSE streaming in the LLB's /v1/responses endpoint"}
-        ]}]}
-        result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Implement SSE streaming in the LLB's /v1/responses endpoint",
+                        }
+                    ],
+                }
+            ]
+        }
+        result_tools, meta = _process_tools_array(
+            REALISTIC_TOOL_SET, prompt_body, "live"
+        )
         surviving = _tool_names(result_tools)
         # At minimum, all core coding tools must survive
         for tool in CORE_CODING_TOOLS:
             assert tool in surviving, f"Safety floor failed to preserve {tool}"
 
     def test_live_never_returns_empty(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Do something complex with network endpoints and sudo"}
-        ]}]}
-        result_tools, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Do something complex with network endpoints and sudo",
+                        }
+                    ],
+                }
+            ]
+        }
+        result_tools, meta = _process_tools_array(
+            REALISTIC_TOOL_SET, prompt_body, "live"
+        )
         assert len(result_tools) > 0
 
     def test_safety_floor_constants_include_essentials(self):
@@ -191,27 +306,42 @@ class TestSafetyFloor:
 
 # ── 5. Decisions log shows stage metadata ────────────────────────────────────
 
+
 class TestDecisionMetadata:
     def test_meta_includes_strategy(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Read the file"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Read the file"}]}
+            ]
+        }
         _, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         assert meta["strategy"] == "conservative"
 
     def test_meta_includes_flag_tiers(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement the endpoint handler"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Implement the endpoint handler"}
+                    ],
+                }
+            ]
+        }
         _, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         assert "hard_capability_flags" in meta
         assert "heuristic_capability_flags" in meta
         assert "required_capability_flags" in meta
 
     def test_meta_includes_stage_counts(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Read the config file"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Read the config file"}],
+                }
+            ]
+        }
         _, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         assert "stage1_survivor_count" in meta
         assert "safety_floor_activated" in meta
@@ -219,18 +349,33 @@ class TestDecisionMetadata:
         assert isinstance(meta["heuristic_would_reject"], list)
 
     def test_meta_includes_heuristic_would_reject(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement SSE streaming in the LLB's /v1/responses endpoint"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Implement SSE streaming in the LLB's /v1/responses endpoint",
+                        }
+                    ],
+                }
+            ]
+        }
         _, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "live")
         # Heuristic would have rejected some tools that lack SUPPORTS_NETWORK
         assert meta["heuristic_would_reject_count"] >= 0
         assert isinstance(meta["heuristic_would_reject"], list)
 
     def test_shadow_meta_also_includes_stage_metadata(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Implement the endpoint"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Implement the endpoint"}],
+                }
+            ]
+        }
         _, meta = _process_tools_array(REALISTIC_TOOL_SET, prompt_body, "shadow")
         assert meta["strategy"] == "shadow"
         assert "hard_capability_flags" in meta
@@ -238,6 +383,7 @@ class TestDecisionMetadata:
 
 
 # ── Derivation tier split correctness ────────────────────────────────────────
+
 
 class TestDerivationTierSplit:
     def test_neutral_prompt_has_zero_hard_and_heuristic(self):
@@ -268,21 +414,41 @@ class TestDerivationTierSplit:
 
 FULL_TOOL_SET = _make_tools(
     # Built-ins
-    "Read", "Edit", "MultiEdit", "Write", "Glob", "Grep", "Bash",
-    "Agent", "EnterPlanMode", "AskUserQuestion", "Think", "Skill",
+    "Read",
+    "Edit",
+    "MultiEdit",
+    "Write",
+    "Glob",
+    "Grep",
+    "Bash",
+    "Agent",
+    "EnterPlanMode",
+    "AskUserQuestion",
+    "Think",
+    "Skill",
     # Allowed MCP servers
-    "mcp__filesystem__read_file", "mcp__filesystem__list_directory",
-    "mcp__git__git_status", "mcp__git__git_diff",
-    "mcp__chatsearch__chatsearch_find", "mcp__chatsearch__chatsearch_ask",
-    "mcp__notion-agents__chat_with_agent", "mcp__notion-agents__query_database",
+    "mcp__filesystem__read_file",
+    "mcp__filesystem__list_directory",
+    "mcp__git__git_status",
+    "mcp__git__git_diff",
+    "mcp__chatsearch__chatsearch_find",
+    "mcp__chatsearch__chatsearch_ask",
+    "mcp__notion-agents__chat_with_agent",
+    "mcp__notion-agents__query_database",
     "mcp__fetch__fetch",
     # Disallowed MCP servers (should be filtered in live mode)
-    "mcp__proxmox__get_vms", "mcp__proxmox__start_vm", "mcp__proxmox__stop_vm",
-    "mcp__playwright__browser_click", "mcp__playwright__browser_snapshot",
-    "mcp__claude_ai_tally__list_forms", "mcp__claude_ai_tally__create_blocks",
-    "mcp__claude_ai_Vercel__deploy_to_vercel", "mcp__claude_ai_Vercel__list_projects",
+    "mcp__proxmox__get_vms",
+    "mcp__proxmox__start_vm",
+    "mcp__proxmox__stop_vm",
+    "mcp__playwright__browser_click",
+    "mcp__playwright__browser_snapshot",
+    "mcp__claude_ai_tally__list_forms",
+    "mcp__claude_ai_tally__create_blocks",
+    "mcp__claude_ai_Vercel__deploy_to_vercel",
+    "mcp__claude_ai_Vercel__list_projects",
     "mcp__plugin:Notion:notion__notion-create-pages",
-    "mcp__bay-view-graph__list_emails", "mcp__bay-view-graph__send_email",
+    "mcp__bay-view-graph__list_emails",
+    "mcp__bay-view-graph__send_email",
     "mcp__claude_ai_Google_Calendar__gcal_list_events",
     "mcp__claude_ai_Gmail__gmail_search_messages",
 )
@@ -292,9 +458,16 @@ class TestServerLevelFiltering:
     """Stage 2: Budget-aware server-level MCP filtering."""
 
     def test_disallowed_servers_removed_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Read the config file and fix the bug"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Read the config file and fix the bug"}
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         # Proxmox, Playwright, Tally, Vercel, Bay-View-Graph, Calendar, Gmail should be gone
@@ -308,9 +481,14 @@ class TestServerLevelFiltering:
         assert "mcp__claude_ai_Gmail__gmail_search_messages" not in surviving
 
     def test_allowed_servers_preserved_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Read the config file"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Read the config file"}],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__filesystem__read_file" in surviving
@@ -320,33 +498,41 @@ class TestServerLevelFiltering:
         assert "mcp__fetch__fetch" in surviving
 
     def test_builtins_never_server_filtered(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Do something"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Do something"}]}
+            ]
+        }
         result_tools, _ = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         for tool in CORE_CODING_TOOLS:
             assert tool in surviving
 
     def test_shadow_preserves_all(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Do something"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Do something"}]}
+            ]
+        }
         result_tools, _ = _process_tools_array(FULL_TOOL_SET, prompt_body, "shadow")
         assert len(result_tools) == len(FULL_TOOL_SET)
 
     def test_meta_reports_server_filtered(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Fix the bug"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Fix the bug"}]}
+            ]
+        }
         _, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         assert meta["server_filtered_count"] > 0
         assert "mcp__proxmox__get_vms" in meta["server_filtered"]
 
     def test_reduction_is_significant(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "Fix the bug"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Fix the bug"}]}
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         reduction = 1 - len(result_tools) / len(FULL_TOOL_SET)
         assert reduction >= 0.25, f"Expected >=25% reduction, got {reduction:.0%}"
@@ -365,15 +551,30 @@ class TestServerLevelFiltering:
         old = os.environ.get("TCP_PROXY_WORKSPACE_MCP_SERVERS")
         os.environ["TCP_PROXY_WORKSPACE_MCP_SERVERS"] = "bay-view-graph"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Check email from Jason from today"}
-            ]}]}
-            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Check email from Jason from today",
+                            }
+                        ],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                FULL_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             assert "mcp__bay-view-graph__list_emails" in surviving
             assert "mcp__bay-view-graph__send_email" in surviving
             assert meta["pack_states"]["workspace-critical"] == "deferred"
-            assert "workspace_allow" in meta["pack_activation_reasons"]["workspace-critical"]
+            assert (
+                "workspace_allow"
+                in meta["pack_activation_reasons"]["workspace-critical"]
+            )
             assert "bay-view-graph" in meta["workspace_allowed_servers"]
             assert "mcp__bay-view-graph__list_emails" in meta["workspace_rescued"]
             assert "mcp__bay-view-graph__list_emails" in meta["deferred_visible"]
@@ -388,14 +589,29 @@ class TestServerLevelFiltering:
         old = os.environ.get("TCP_PROXY_WORKSPACE_PROFILE")
         os.environ["TCP_PROXY_WORKSPACE_PROFILE"] = "bay-view"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Check email from Jason from today"}
-            ]}]}
-            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Check email from Jason from today",
+                            }
+                        ],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                FULL_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             assert "mcp__bay-view-graph__list_emails" in surviving
             assert meta["pack_states"]["workspace-critical"] == "active"
-            assert "profile:bay-view" in meta["pack_activation_reasons"]["workspace-critical"]
+            assert (
+                "profile:bay-view"
+                in meta["pack_activation_reasons"]["workspace-critical"]
+            )
             assert meta["server_allow_source"]["bay-view-graph"] == "pack_active"
         finally:
             if old is None:
@@ -409,14 +625,29 @@ class TestServerLevelFiltering:
         os.environ.pop("TCP_PROXY_WORKSPACE_PROFILE", None)
         os.environ["TCP_PROXY_PROFILE"] = "bay-view"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Check email from Jason from today"}
-            ]}]}
-            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Check email from Jason from today",
+                            }
+                        ],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                FULL_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             assert "mcp__bay-view-graph__list_emails" in surviving
             assert meta["pack_states"]["workspace-critical"] == "active"
-            assert "profile:bay-view" in meta["pack_activation_reasons"]["workspace-critical"]
+            assert (
+                "profile:bay-view"
+                in meta["pack_activation_reasons"]["workspace-critical"]
+            )
             assert meta["server_allow_source"]["bay-view-graph"] == "pack_active"
         finally:
             if old_ws is None:
@@ -429,9 +660,19 @@ class TestServerLevelFiltering:
                 os.environ["TCP_PROXY_PROFILE"] = old_profile
 
     def test_explicit_tool_name_rescues_server_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "use mcp__bay-view-graph__list_emails to check email from Jason"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "use mcp__bay-view-graph__list_emails to check email from Jason",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__bay-view-graph__list_emails" in surviving
@@ -439,19 +680,41 @@ class TestServerLevelFiltering:
         assert meta["server_allow_source"]["bay-view-graph"] == "explicit_request"
 
     def test_mixed_case_server_name_rescues_server_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "please use claude_ai_vercel for deployment status"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "please use claude_ai_vercel for deployment status",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__claude_ai_Vercel__deploy_to_vercel" in surviving
-        assert "mcp__claude_ai_Vercel__deploy_to_vercel" in meta["explicit_server_rescued"]
+        assert (
+            "mcp__claude_ai_Vercel__deploy_to_vercel" in meta["explicit_server_rescued"]
+        )
         assert meta["server_allow_source"]["claude_ai_Vercel"] == "explicit_request"
 
     def test_plugin_server_phrase_rescues_plugin_tools_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "try notion plugin and log the admin work"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "try notion plugin and log the admin work",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__plugin:Notion:notion__notion-create-pages" in surviving
@@ -462,12 +725,19 @@ class TestServerLevelFiltering:
         assert meta["server_allow_source"]["plugin:Notion:notion"] == "explicit_request"
 
     def test_notion_api_phrase_rescues_plugin_tools_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {
-                "type": "text",
-                "text": "the skill requires a notionapi mcp server so try the notion api path",
-            }
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "the skill requires a notionapi mcp server so try the notion api path",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__plugin:Notion:notion__notion-create-pages" in surviving
@@ -478,9 +748,19 @@ class TestServerLevelFiltering:
         assert meta["server_allow_source"]["plugin:Notion:notion"] == "explicit_request"
 
     def test_claude_connector_phrase_rescues_gmail_server_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "use the claude gmail plugin to find the renewal email"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "use the claude gmail plugin to find the renewal email",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__claude_ai_Gmail__gmail_search_messages" in surviving
@@ -491,9 +771,19 @@ class TestServerLevelFiltering:
         assert meta["server_allow_source"]["claude_ai_Gmail"] == "explicit_request"
 
     def test_claude_connector_phrase_rescues_google_calendar_server_in_live(self):
-        prompt_body = {"messages": [{"role": "user", "content": [
-            {"type": "text", "text": "check the google calendar claude plugin for next rehearsal"}
-        ]}]}
+        prompt_body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "check the google calendar claude plugin for next rehearsal",
+                        }
+                    ],
+                }
+            ]
+        }
         result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
         surviving = _tool_names(result_tools)
         assert "mcp__claude_ai_Google_Calendar__gcal_list_events" in surviving
@@ -510,10 +800,17 @@ class TestServerLevelFiltering:
         old = os.environ.get("TCP_PROXY_ALLOWED_MCP_SERVERS")
         os.environ["TCP_PROXY_ALLOWED_MCP_SERVERS"] = "filesystem,git"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Fix the bug"}
-            ]}]}
-            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Fix the bug"}],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                FULL_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             # core-coding pack is an absolute safety floor and is not suppressed
             # by the hard allow override; workspace-critical packs still are.
@@ -535,10 +832,22 @@ class TestServerLevelFiltering:
         os.environ["TCP_PROXY_ALLOWED_MCP_SERVERS"] = "filesystem,git"
         os.environ["TCP_PROXY_WORKSPACE_MCP_SERVERS"] = "bay-view-graph"
         try:
-            prompt_body = {"messages": [{"role": "user", "content": [
-                {"type": "text", "text": "Check email from Jason from today"}
-            ]}]}
-            result_tools, meta = _process_tools_array(FULL_TOOL_SET, prompt_body, "live")
+            prompt_body = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Check email from Jason from today",
+                            }
+                        ],
+                    }
+                ]
+            }
+            result_tools, meta = _process_tools_array(
+                FULL_TOOL_SET, prompt_body, "live"
+            )
             surviving = _tool_names(result_tools)
             assert "mcp__bay-view-graph__list_emails" not in surviving
             assert meta["workspace_allowed_servers"] == []


### PR DESCRIPTION
## Summary
- replace per-request upstream clients in  with a lifespan-managed shared 
- preserve 600s total / 30s connect timeout while setting explicit connection-pool limits and bounded retry behavior
- extend  records with additive timing fields and retry metadata without removing existing keys

## Retry semantics
- retries are bounded to 1 retry total ( attempts max)
-  retries only connect/pool establishment failures before any response bytes exist
- pass-through safe methods (, , ) may retry a pre-first-byte read failure once
- no retry occurs after any upstream response bytes have been observed

## Telemetry
- 
- 
- 
- 
- 

## Validation
- ........................................................................ [ 91%]
.......                                                                  [100%]

Closes #66