### PR TITLE
Add shared-proxy session attribution

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -1015,9 +1015,12 @@ async def proxy_post_messages(request: Request) -> Response:
     started_at = time.perf_counter()
     raw = await request.body()
     req_ts = time.time()
+    request_port = request.url.port
+    session_registry = getattr(request.app.state, "session_registry", None)
+    if request_port is not None and session_registry is not None:
+        session_registry.proxy_port = request_port
     session_ctx: SessionContext | None = None
     if request.client is not None:
-        session_registry = getattr(request.app.state, "session_registry", None)
         if session_registry is not None:
             session_ctx = session_registry.context_for_peer(
                 request.client.host,
@@ -1066,7 +1069,7 @@ async def proxy_post_messages(request: Request) -> Response:
                 "event": "request_ready",
                 "path": "/v1/messages",
                 "stream": stream,
-                "upstream_url": url,
+                "upstream_url": f"{_upstream_base()}/v1/messages",
             },
         )
 

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -51,6 +51,7 @@ from tcp.proxy.pack_manifest import (
 )
 from tcp.proxy.projection import ProjectionTier, project_single_anthropic_tool
 from tcp.proxy.prompt_select import extract_task_prompt
+from tcp.proxy.session_registry import SessionContext, SessionRegistry
 
 PROXY_STATE_DIR = Path.home() / ".tcp-shadow" / "proxy"
 MODE_PATH = PROXY_STATE_DIR / "mode"
@@ -218,6 +219,18 @@ def _session_from_env() -> SessionStartEvent:
     )
 
 
+def _session_start_event_for_context(
+    session_ctx: SessionContext | None,
+) -> SessionStartEvent:
+    if session_ctx is None:
+        return _session_from_env()
+    return SessionStartEvent(
+        session_id=session_ctx.session_id,
+        permission_mode=os.environ.get("TCP_PROXY_PERMISSION_MODE", "default"),
+        cwd=session_ctx.client_cwd or os.environ.get("TCP_PROXY_CWD", os.getcwd()),
+    )
+
+
 def _deferred_tool_surface(
     tool: Mapping[str, Any],
     *,
@@ -330,6 +343,7 @@ def _process_tools_array(
     tools: list[Any],
     body: Mapping[str, Any],
     mode: str,
+    session_ctx: SessionContext | None = None,
 ) -> tuple[list[Any], dict[str, Any]]:
     """Run 4-stage projection + gating pipeline.
 
@@ -346,7 +360,7 @@ def _process_tools_array(
     """
     messages = body.get("messages")
     prompt = extract_task_prompt(messages if isinstance(messages, list) else None)
-    session = _session_from_env()
+    session = _session_start_event_for_context(session_ctx)
     tsel = derive_request(prompt, session)
     env = _runtime_from_env()
 
@@ -673,7 +687,9 @@ def _process_tools_array(
 
 
 def _maybe_transform_messages_body(
-    raw: bytes, mode: str
+    raw: bytes,
+    mode: str,
+    session_ctx: SessionContext | None = None,
 ) -> tuple[bytes, dict[str, Any] | None]:
     try:
         body = json.loads(raw)
@@ -685,7 +701,7 @@ def _maybe_transform_messages_body(
     if not isinstance(tools, list):
         return raw, None
 
-    new_tools, meta = _process_tools_array(tools, body, mode)
+    new_tools, meta = _process_tools_array(tools, body, mode, session_ctx)
     if mode == "shadow":
         return raw, meta
 
@@ -824,6 +840,7 @@ def _write_decision_record(
     first_byte_duration_ms: float | None = None,
     total_response_duration_ms: float | None = None,
     retry_count: int = 0,
+    session_ctx: SessionContext | None = None,
 ) -> None:
     """Write (or rewrite) the enriched decisions.jsonl entry for this turn."""
     expected_tool_name = _compute_expected_tool_name(meta)
@@ -831,23 +848,33 @@ def _write_decision_record(
     if first_tool_name is not None and expected_tool_name is not None:
         first_tool_correct = first_tool_name == expected_tool_name
 
-    _append_jsonl(
-        DECISIONS_LOG,
-        {
-            "ts": req_ts,
-            "path": "/v1/messages",
-            **meta,
-            "first_tool_name": first_tool_name,
-            "expected_tool_name": expected_tool_name,
-            "first_tool_correct": first_tool_correct,
-            "tap_skipped": tap_skipped,
-            "preflight_duration_ms": preflight_duration_ms,
-            "upstream_request_duration_ms": upstream_request_duration_ms,
-            "first_byte_duration_ms": first_byte_duration_ms,
-            "total_response_duration_ms": total_response_duration_ms,
-            "retry_count": retry_count,
-        },
-    )
+    record = {
+        "ts": req_ts,
+        "path": "/v1/messages",
+        **meta,
+        "first_tool_name": first_tool_name,
+        "expected_tool_name": expected_tool_name,
+        "first_tool_correct": first_tool_correct,
+        "tap_skipped": tap_skipped,
+        "preflight_duration_ms": preflight_duration_ms,
+        "upstream_request_duration_ms": upstream_request_duration_ms,
+        "first_byte_duration_ms": first_byte_duration_ms,
+        "total_response_duration_ms": total_response_duration_ms,
+        "retry_count": retry_count,
+    }
+    if session_ctx is not None:
+        record.update(
+            {
+                "session_id": session_ctx.session_id,
+                "session_start_ts": session_ctx.session_start_ts,
+                "proxy_pid": session_ctx.proxy_pid,
+                "proxy_port": session_ctx.proxy_port,
+                "concurrent_sessions": session_ctx.concurrent_sessions,
+            }
+        )
+    _append_jsonl(DECISIONS_LOG, record)
+    if session_ctx is not None:
+        _append_jsonl(session_ctx.decisions_path, record)
 
 
 def _forward_headers(request: Request) -> dict[str, str]:
@@ -988,8 +1015,29 @@ async def proxy_post_messages(request: Request) -> Response:
     started_at = time.perf_counter()
     raw = await request.body()
     req_ts = time.time()
-    transformed, meta = _maybe_transform_messages_body(raw, mode)
+    session_ctx: SessionContext | None = None
+    if request.client is not None:
+        session_registry = getattr(request.app.state, "session_registry", None)
+        if session_registry is not None:
+            session_ctx = session_registry.context_for_peer(
+                request.client.host,
+                request.client.port,
+            )
+    transformed, meta = _maybe_transform_messages_body(raw, mode, session_ctx)
     preflight_done_at = time.perf_counter()
+    if session_ctx is not None:
+        request.app.state.session_registry.append_request_event(
+            session_ctx,
+            {
+                "ts": req_ts,
+                "event": "request_started",
+                "path": "/v1/messages",
+                "method": "POST",
+                "client_host": request.client.host if request.client is not None else None,
+                "client_port": request.client.port if request.client is not None else None,
+                "stream": False,
+            },
+        )
     # Decision record is written AFTER response tapping so first_tool_name,
     # expected_tool_name, and first_tool_correct can be included in one record.
 
@@ -1010,6 +1058,17 @@ async def proxy_post_messages(request: Request) -> Response:
         stream = bool(parsed.get("stream")) if isinstance(parsed, dict) else False
     except json.JSONDecodeError:
         stream = False
+    if session_ctx is not None:
+        request.app.state.session_registry.append_request_event(
+            session_ctx,
+            {
+                "ts": time.time(),
+                "event": "request_ready",
+                "path": "/v1/messages",
+                "stream": stream,
+                "upstream_url": url,
+            },
+        )
 
     client = _get_upstream_client(request)
     upstream_started_at = time.perf_counter()
@@ -1040,6 +1099,16 @@ async def proxy_post_messages(request: Request) -> Response:
                 ),
                 total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
                 retry_count=retry_count,
+                session_ctx=session_ctx,
+            )
+        if session_ctx is not None:
+            request.app.state.session_registry.append_request_event(
+                session_ctx,
+                {
+                    "ts": time.time(),
+                    "event": "upstream_error",
+                    "path": "/v1/messages",
+                },
             )
         raise
 
@@ -1097,6 +1166,7 @@ async def proxy_post_messages(request: Request) -> Response:
                                     else None
                                 ),
                                 retry_count=retry_count,
+                                session_ctx=session_ctx,
                             )
                             _tap["done"] = True
                             _tap["buf"] = b""  # release buffer memory
@@ -1132,6 +1202,7 @@ async def proxy_post_messages(request: Request) -> Response:
                         total_response_duration_ms=(time.perf_counter() - started_at)
                         * 1000.0,
                         retry_count=retry_count,
+                        session_ctx=session_ctx,
                     )
                     _tap["done"] = True
                 elif meta is not None and not can_tap:
@@ -1155,6 +1226,17 @@ async def proxy_post_messages(request: Request) -> Response:
                         total_response_duration_ms=(time.perf_counter() - started_at)
                         * 1000.0,
                         retry_count=retry_count,
+                        session_ctx=session_ctx,
+                    )
+                if session_ctx is not None:
+                    request.app.state.session_registry.append_request_event(
+                        session_ctx,
+                        {
+                            "ts": time.time(),
+                            "event": "response_stream_closed",
+                            "path": "/v1/messages",
+                            "status_code": response.status_code,
+                        },
                     )
                 await response.aclose()
 
@@ -1191,6 +1273,18 @@ async def proxy_post_messages(request: Request) -> Response:
                 ),
                 total_response_duration_ms=(time.perf_counter() - started_at) * 1000.0,
                 retry_count=retry_count,
+                session_ctx=session_ctx,
+            )
+        if session_ctx is not None:
+            request.app.state.session_registry.append_request_event(
+                session_ctx,
+                {
+                    "ts": time.time(),
+                    "event": "response_buffered",
+                    "path": "/v1/messages",
+                    "status_code": response.status_code,
+                    "content_length": len(content),
+                },
             )
         return Response(
             content=content,
@@ -1276,7 +1370,7 @@ async def health(_: Request) -> PlainTextResponse:
 
 
 def build_app() -> Starlette:
-    return Starlette(
+    app = Starlette(
         lifespan=_app_lifespan,
         routes=[
             Route("/health", health, methods=["GET"]),
@@ -1290,6 +1384,12 @@ def build_app() -> Starlette:
             ),
         ],
     )
+    proxy_port = int(os.environ.get("TCP_CC_PROXY_PORT", "8742"))
+    app.state.session_registry = SessionRegistry(
+        state_dir=PROXY_STATE_DIR,
+        proxy_port=proxy_port,
+    )
+    return app
 
 
 def _doctor_payload(inspection: PackInspection) -> dict[str, Any]:

--- a/tcp/proxy/session_registry.py
+++ b/tcp/proxy/session_registry.py
@@ -62,11 +62,19 @@ class SessionRegistry:
         self._by_peer: dict[tuple[str, int], SessionContext] = {}
         self._last_reap_at = 0.0
 
+    @property
+    def proxy_port(self) -> int:
+        return self._proxy_port
+
+    @proxy_port.setter
+    def proxy_port(self, value: int) -> None:
+        self._proxy_port = value
+
     def context_for_peer(self, client_host: str, client_port: int) -> SessionContext:
         self._reap_stale_sessions()
         peer = (client_host, client_port)
         existing = self._by_peer.get(peer)
-        if existing and self._pid_is_alive(existing.client_pid):
+        if existing and self._session_is_active(existing.client_pid):
             return self._refresh(existing)
 
         client_pid = self._resolve_client_pid(client_host, client_port)
@@ -130,7 +138,13 @@ class SessionRegistry:
         count = 0
         for lock_path in self._sessions_dir.glob("*/session.lock"):
             payload = self._read_lock(lock_path)
-            if payload and self._pid_is_alive(payload.get("client_pid")):
+            if not payload:
+                continue
+            if payload.get("proxy_pid") != self._proxy_pid:
+                continue
+            if payload.get("proxy_port") != self._proxy_port:
+                continue
+            if self._session_is_active(payload.get("client_pid")):
                 count += 1
         return count
 
@@ -142,13 +156,18 @@ class SessionRegistry:
 
         active_peers: dict[tuple[str, int], SessionContext] = {}
         for peer, ctx in list(self._by_peer.items()):
-            if self._pid_is_alive(ctx.client_pid):
+            if self._session_is_active(ctx.client_pid):
                 active_peers[peer] = ctx
         self._by_peer = active_peers
 
         for lock_path in self._sessions_dir.glob("*/session.lock"):
             payload = self._read_lock(lock_path)
-            if payload and not self._pid_is_alive(payload.get("client_pid")):
+            if (
+                payload
+                and payload.get("proxy_pid") == self._proxy_pid
+                and payload.get("proxy_port") == self._proxy_port
+                and not self._session_is_active(payload.get("client_pid"))
+            ):
                 try:
                     lock_path.unlink()
                 except FileNotFoundError:
@@ -164,6 +183,11 @@ class SessionRegistry:
         if not isinstance(pid, int) or pid <= 0:
             return False
         return (self._proc_root / str(pid)).exists()
+
+    def _session_is_active(self, pid: object) -> bool:
+        if pid is None:
+            return True
+        return self._pid_is_alive(pid)
 
     def _resolve_cwd(self, pid: int | None) -> str:
         if pid is None:
@@ -191,6 +215,8 @@ class SessionRegistry:
         ss_pid = self._lookup_pid_via_ss(client_port)
         if ss_pid is not None:
             return ss_pid
+        if client_host in {"::1", "localhost"}:
+            return None
         inode = self._lookup_inode_for_peer_port(client_port)
         if inode is None:
             return None

--- a/tcp/proxy/session_registry.py
+++ b/tcp/proxy/session_registry.py
@@ -1,0 +1,285 @@
+"""Session attribution and lifecycle artifacts for the shared TCP proxy.
+
+Phase 1 keeps the stable shared listener on 127.0.0.1:8742, but routes and
+telemeters requests with a proxy-local session identity derived from the owning
+Claude process behind each loopback TCP connection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_PROC_TCP_PATH = Path("/proc/net/tcp")
+_PROC_ROOT = Path("/proc")
+
+
+@dataclass(frozen=True)
+class SessionContext:
+    session_id: str
+    session_start_ts: float
+    client_pid: int | None
+    client_cwd: str
+    proxy_pid: int
+    proxy_port: int
+    concurrent_sessions: int
+    lock_path: Path
+    log_path: Path
+    decisions_path: Path
+
+
+class SessionRegistry:
+    """Resolve and persist session-local artifacts for the shared proxy.
+
+    Attribution is best-effort from the loopback peer connection. Once a peer
+    port has been resolved to a Claude PID we cache it, persist a lockfile, and
+    reuse the generated session identity for subsequent requests on that socket.
+    """
+
+    def __init__(
+        self,
+        *,
+        state_dir: Path,
+        proxy_port: int,
+        proxy_pid: int | None = None,
+        proc_root: Path = _PROC_ROOT,
+        proc_tcp_path: Path = _PROC_TCP_PATH,
+    ) -> None:
+        self._state_dir = state_dir
+        self._sessions_dir = state_dir / "sessions"
+        self._sessions_dir.mkdir(parents=True, exist_ok=True)
+        self._proxy_port = proxy_port
+        self._proxy_pid = proxy_pid if proxy_pid is not None else os.getpid()
+        self._proc_root = proc_root
+        self._proc_tcp_path = proc_tcp_path
+        self._by_peer: dict[tuple[str, int], SessionContext] = {}
+        self._last_reap_at = 0.0
+
+    def context_for_peer(self, client_host: str, client_port: int) -> SessionContext:
+        self._reap_stale_sessions()
+        peer = (client_host, client_port)
+        existing = self._by_peer.get(peer)
+        if existing and self._pid_is_alive(existing.client_pid):
+            return self._refresh(existing)
+
+        client_pid = self._resolve_client_pid(client_host, client_port)
+        client_cwd = self._resolve_cwd(client_pid)
+        session_id = self._session_id_for(client_pid, client_cwd, peer)
+        session_start_ts = time.time()
+        session_dir = self._sessions_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        ctx = SessionContext(
+            session_id=session_id,
+            session_start_ts=session_start_ts,
+            client_pid=client_pid,
+            client_cwd=client_cwd,
+            proxy_pid=self._proxy_pid,
+            proxy_port=self._proxy_port,
+            concurrent_sessions=0,
+            lock_path=session_dir / "session.lock",
+            log_path=session_dir / "requests.jsonl",
+            decisions_path=session_dir / "decisions.jsonl",
+        )
+        self._persist_lock(ctx)
+        ctx = self._refresh(ctx)
+        self._by_peer[peer] = ctx
+        return ctx
+
+    def append_request_event(self, ctx: SessionContext, record: dict[str, object]) -> None:
+        self._append_jsonl(ctx.log_path, record)
+
+    def _refresh(self, ctx: SessionContext) -> SessionContext:
+        concurrent_sessions = self._count_live_sessions()
+        refreshed = SessionContext(
+            session_id=ctx.session_id,
+            session_start_ts=ctx.session_start_ts,
+            client_pid=ctx.client_pid,
+            client_cwd=ctx.client_cwd,
+            proxy_pid=ctx.proxy_pid,
+            proxy_port=ctx.proxy_port,
+            concurrent_sessions=concurrent_sessions,
+            lock_path=ctx.lock_path,
+            log_path=ctx.log_path,
+            decisions_path=ctx.decisions_path,
+        )
+        self._persist_lock(refreshed)
+        return refreshed
+
+    def _persist_lock(self, ctx: SessionContext) -> None:
+        payload = {
+            "session_id": ctx.session_id,
+            "session_start_ts": ctx.session_start_ts,
+            "client_pid": ctx.client_pid,
+            "client_cwd": ctx.client_cwd,
+            "proxy_pid": ctx.proxy_pid,
+            "proxy_port": ctx.proxy_port,
+            "last_seen_ts": time.time(),
+        }
+        tmp = ctx.lock_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, ctx.lock_path)
+
+    def _count_live_sessions(self) -> int:
+        count = 0
+        for lock_path in self._sessions_dir.glob("*/session.lock"):
+            payload = self._read_lock(lock_path)
+            if payload and self._pid_is_alive(payload.get("client_pid")):
+                count += 1
+        return count
+
+    def _reap_stale_sessions(self) -> None:
+        now = time.time()
+        if now - self._last_reap_at < 5.0:
+            return
+        self._last_reap_at = now
+
+        active_peers: dict[tuple[str, int], SessionContext] = {}
+        for peer, ctx in list(self._by_peer.items()):
+            if self._pid_is_alive(ctx.client_pid):
+                active_peers[peer] = ctx
+        self._by_peer = active_peers
+
+        for lock_path in self._sessions_dir.glob("*/session.lock"):
+            payload = self._read_lock(lock_path)
+            if payload and not self._pid_is_alive(payload.get("client_pid")):
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+
+    def _read_lock(self, path: Path) -> dict[str, object] | None:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _pid_is_alive(self, pid: object) -> bool:
+        if not isinstance(pid, int) or pid <= 0:
+            return False
+        return (self._proc_root / str(pid)).exists()
+
+    def _resolve_cwd(self, pid: int | None) -> str:
+        if pid is None:
+            return ""
+        try:
+            return os.readlink(self._proc_root / str(pid) / "cwd")
+        except OSError:
+            return ""
+
+    def _session_id_for(
+        self,
+        client_pid: int | None,
+        client_cwd: str,
+        peer: tuple[str, int],
+    ) -> str:
+        material = f"{client_pid}:{client_cwd}:{peer[0]}:{peer[1]}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+        if client_pid is not None:
+            return f"proxy-{client_pid}-{digest}"
+        return f"proxy-peer-{peer[1]}-{digest}"
+
+    def _resolve_client_pid(self, client_host: str, client_port: int) -> int | None:
+        if client_host not in {"127.0.0.1", "::1", "localhost"}:
+            return None
+        ss_pid = self._lookup_pid_via_ss(client_port)
+        if ss_pid is not None:
+            return ss_pid
+        inode = self._lookup_inode_for_peer_port(client_port)
+        if inode is None:
+            return None
+        return self._lookup_pid_by_inode(inode)
+
+    def _lookup_pid_via_ss(self, client_port: int) -> int | None:
+        try:
+            result = subprocess.run(
+                ["ss", "-tnp"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None
+
+        target_local = f":{client_port}"
+        target_remote = f":{self._proxy_port}"
+        for raw_line in result.stdout.splitlines():
+            line = raw_line.strip()
+            if not line.startswith("ESTAB"):
+                continue
+            if target_local not in line or target_remote not in line:
+                continue
+            columns = line.split()
+            if len(columns) < 6:
+                continue
+            local_addr = columns[3]
+            remote_addr = columns[4]
+            if not local_addr.endswith(target_local):
+                continue
+            if not remote_addr.endswith(target_remote):
+                continue
+            match = re.search(r"pid=(\d+)", line)
+            if match is None:
+                continue
+            try:
+                return int(match.group(1))
+            except ValueError:
+                return None
+        return None
+
+    def _lookup_inode_for_peer_port(self, client_port: int) -> int | None:
+        try:
+            lines = self._proc_tcp_path.read_text(encoding="utf-8").splitlines()[1:]
+        except OSError:
+            return None
+        target_local = f"{self._proxy_port:04X}"
+        target_remote = f"{client_port:04X}"
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 10:
+                continue
+            local_addr, remote_addr, state = parts[1], parts[2], parts[3]
+            inode = parts[9]
+            try:
+                local_port = local_addr.split(":")[1]
+                remote_port = remote_addr.split(":")[1]
+            except IndexError:
+                continue
+            if local_port == target_local and remote_port == target_remote and state == "01":
+                try:
+                    return int(inode)
+                except ValueError:
+                    return None
+        return None
+
+    def _lookup_pid_by_inode(self, inode: int) -> int | None:
+        needle = f"socket:[{inode}]"
+        for proc_path in self._proc_root.iterdir():
+            if not proc_path.name.isdigit():
+                continue
+            fd_dir = proc_path / "fd"
+            if not fd_dir.exists():
+                continue
+            try:
+                for fd_path in fd_dir.iterdir():
+                    try:
+                        if os.readlink(fd_path) == needle:
+                            return int(proc_path.name)
+                    except OSError:
+                        continue
+            except OSError:
+                continue
+        return None
+
+    def _append_jsonl(self, path: Path, record: dict[str, object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -350,6 +350,68 @@ def test_messages_telemetry_fields_are_populated(tmp_path) -> None:
         assert record[key] >= 0.0
 
 
+def test_request_log_omits_query_string_and_syncs_registry_port(tmp_path) -> None:
+    body = json.dumps(
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}}
+            ],
+            "model": "claude-3-5-sonnet-20241022",
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    )
+    upstream = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                content=body.encode(),
+                headers={"content-type": "application/json"},
+            )
+        )
+    )
+    with patch("tcp.proxy.cc_proxy._build_upstream_client", return_value=upstream):
+        with patch("tcp.proxy.cc_proxy._read_mode", return_value="shadow"):
+            with patch("tcp.proxy.cc_proxy.PROXY_STATE_DIR", tmp_path):
+                with patch.dict("os.environ", {"TCP_CC_PROXY_PORT": "9999"}):
+                    app = build_app()
+                    payload = json.dumps(
+                        {
+                            "model": "claude-3-5-sonnet-20241022",
+                            "max_tokens": 10,
+                            "messages": [{"role": "user", "content": "run bash"}],
+                            "tools": [
+                                {
+                                    "name": "Bash",
+                                    "description": "shell",
+                                    "input_schema": {"type": "object"},
+                                }
+                            ],
+                        }
+                    )
+                    with TestClient(app, base_url="http://testserver:8742") as client:
+                        response = client.post(
+                            "/v1/messages?api_key=secret",
+                            content=payload,
+                            headers={
+                                "content-type": "application/json",
+                                "x-api-key": "sk-test",
+                            },
+                        )
+
+    assert response.status_code == 200
+    assert app.state.session_registry.proxy_port == 8742
+    request_logs = list((tmp_path / "sessions").glob("*/requests.jsonl"))
+    assert len(request_logs) == 1
+    lines = request_logs[0].read_text(encoding="utf-8").splitlines()
+    request_ready = next(json.loads(line) for line in lines if '"event": "request_ready"' in line)
+    assert request_ready["upstream_url"] == "https://api.anthropic.com/v1/messages"
+
+
 def test_decision_record_includes_session_fields_and_per_session_copy() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         log_path = Path(tmpdir) / "decisions.jsonl"

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -28,6 +28,7 @@ from tcp.proxy.cc_proxy import (
     _write_decision_record,
     build_app,
 )
+from tcp.proxy.session_registry import SessionContext
 
 
 def test_forward_headers_omit_content_length() -> None:
@@ -347,3 +348,37 @@ def test_messages_telemetry_fields_are_populated(tmp_path) -> None:
     ):
         assert isinstance(record[key], float)
         assert record[key] >= 0.0
+
+
+def test_decision_record_includes_session_fields_and_per_session_copy() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "decisions.jsonl"
+        session_decisions = Path(tmpdir) / "sessions" / "abc" / "decisions.jsonl"
+        session_ctx = SessionContext(
+            session_id="proxy-4242-abcd1234",
+            session_start_ts=123.45,
+            client_pid=4242,
+            client_cwd="/tmp/workspace",
+            proxy_pid=777,
+            proxy_port=8742,
+            concurrent_sessions=3,
+            lock_path=Path(tmpdir) / "sessions" / "abc" / "session.lock",
+            log_path=Path(tmpdir) / "sessions" / "abc" / "requests.jsonl",
+            decisions_path=session_decisions,
+        )
+        with patch("tcp.proxy.cc_proxy.DECISIONS_LOG", log_path):
+            _write_decision_record(
+                1.0,
+                _make_meta(),
+                "bash",
+                tap_skipped=False,
+                session_ctx=session_ctx,
+            )
+        record = json.loads(log_path.read_text(encoding="utf-8"))
+        assert record["session_id"] == "proxy-4242-abcd1234"
+        assert record["session_start_ts"] == 123.45
+        assert record["proxy_pid"] == 777
+        assert record["proxy_port"] == 8742
+        assert record["concurrent_sessions"] == 3
+        per_session = json.loads(session_decisions.read_text(encoding="utf-8"))
+        assert per_session["session_id"] == "proxy-4242-abcd1234"

--- a/tests/unit/test_cc_proxy_session_registry.py
+++ b/tests/unit/test_cc_proxy_session_registry.py
@@ -74,6 +74,7 @@ def test_stale_session_cleanup_removes_dead_lockfiles(tmp_path: Path) -> None:
     registry = SessionRegistry(
         state_dir=tmp_path / "state",
         proxy_port=8742,
+        proxy_pid=555,
         proc_root=proc_root,
         proc_tcp_path=proc_tcp_path,
     )
@@ -83,10 +84,10 @@ def test_stale_session_cleanup_removes_dead_lockfiles(tmp_path: Path) -> None:
     lock_path = dead_dir / "session.lock"
     lock_path.write_text(
         json.dumps(
-            {
-                "session_id": "dead-session",
-                "client_pid": 99999,
-                "proxy_pid": 555,
+                {
+                    "session_id": "dead-session",
+                    "client_pid": 99999,
+                    "proxy_pid": 555,
                 "proxy_port": 8742,
             }
         ),
@@ -128,3 +129,116 @@ def test_resolve_client_pid_prefers_ss_client_side_match(tmp_path: Path, monkeyp
     pid = registry._resolve_client_pid("127.0.0.1", 54000)
 
     assert pid == 4242
+
+
+def test_unknown_pid_peer_context_is_reused(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text("", encoding="utf-8")
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+    registry._resolve_client_pid = lambda host, port: None  # type: ignore[method-assign]
+
+    first = registry.context_for_peer("127.0.0.1", 54000)
+    second = registry.context_for_peer("127.0.0.1", 54000)
+
+    assert second.session_id == first.session_id
+    assert second.session_start_ts == first.session_start_ts
+
+
+def test_stale_session_cleanup_preserves_unknown_pid_lockfiles(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text("", encoding="utf-8")
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proxy_pid=777,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+
+    live_dir = tmp_path / "state" / "sessions" / "unknown-session"
+    live_dir.mkdir(parents=True)
+    lock_path = live_dir / "session.lock"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "session_id": "unknown-session",
+                "client_pid": None,
+                "proxy_pid": 777,
+                "proxy_port": 8742,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registry._last_reap_at = 0.0
+    registry._reap_stale_sessions()
+
+    assert lock_path.exists()
+
+
+def test_count_live_sessions_filters_to_current_proxy_instance(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    (proc_root / "4242").mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text("", encoding="utf-8")
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proxy_pid=777,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+
+    for name, payload in {
+        "mine": {"client_pid": 4242, "proxy_pid": 777, "proxy_port": 8742},
+        "other-pid": {"client_pid": 4242, "proxy_pid": 888, "proxy_port": 8742},
+        "other-port": {"client_pid": 4242, "proxy_pid": 777, "proxy_port": 9999},
+        "unknown": {"client_pid": None, "proxy_pid": 777, "proxy_port": 8742},
+    }.items():
+        lock_dir = tmp_path / "state" / "sessions" / name
+        lock_dir.mkdir(parents=True)
+        (lock_dir / "session.lock").write_text(
+            json.dumps({"session_id": name, **payload}),
+            encoding="utf-8",
+        )
+
+    assert registry._count_live_sessions() == 2
+
+
+def test_ipv6_loopback_without_ss_does_not_fall_back_to_ipv4_proc(
+    tmp_path: Path, monkeypatch
+) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text("", encoding="utf-8")
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+
+    def _fake_run(*args, **kwargs):
+        return CompletedProcess(args=args, returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("tcp.proxy.session_registry.subprocess.run", _fake_run)
+    registry._lookup_inode_for_peer_port = lambda port: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        AssertionError("should not use IPv4 proc fallback for IPv6 loopback")
+    )
+
+    assert registry._resolve_client_pid("::1", 54000) is None

--- a/tests/unit/test_cc_proxy_session_registry.py
+++ b/tests/unit/test_cc_proxy_session_registry.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from tcp.proxy.session_registry import SessionRegistry
+
+
+def _write_proc_tcp(path: Path, *, proxy_port: int, client_port: int, inode: int) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+                (
+                    "   0: 0100007F:"
+                    f"{proxy_port:04X} 0100007F:{client_port:04X} 01 00000000:00000000 "
+                    "00:00000000 00000000  1000        0 "
+                    f"{inode} 1 0000000000000000 20 4 30 10 -1"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_context_for_peer_persists_lock_and_paths(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    (proc_root / "4242").mkdir()
+    (proc_root / "4242" / "fd").mkdir()
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+
+    proc_tcp_path = tmp_path / "proc_tcp"
+    _write_proc_tcp(proc_tcp_path, proxy_port=8742, client_port=54000, inode=12345)
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proxy_pid=777,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+    registry._lookup_pid_by_inode = lambda inode: 4242  # type: ignore[method-assign]
+    registry._resolve_cwd = lambda pid: str(cwd)  # type: ignore[method-assign]
+
+    ctx = registry.context_for_peer("127.0.0.1", 54000)
+
+    assert ctx.session_id.startswith("proxy-4242-")
+    assert ctx.client_pid == 4242
+    assert ctx.client_cwd == str(cwd)
+    assert ctx.proxy_pid == 777
+    assert ctx.proxy_port == 8742
+    assert ctx.concurrent_sessions == 1
+    assert ctx.lock_path.exists()
+    payload = json.loads(ctx.lock_path.read_text(encoding="utf-8"))
+    assert payload["session_id"] == ctx.session_id
+    assert payload["client_pid"] == 4242
+    assert payload["proxy_port"] == 8742
+    assert ctx.log_path.name == "requests.jsonl"
+    assert ctx.decisions_path.name == "decisions.jsonl"
+
+
+def test_stale_session_cleanup_removes_dead_lockfiles(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text(
+        "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n",
+        encoding="utf-8",
+    )
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+
+    dead_dir = tmp_path / "state" / "sessions" / "dead-session"
+    dead_dir.mkdir(parents=True)
+    lock_path = dead_dir / "session.lock"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "session_id": "dead-session",
+                "client_pid": 99999,
+                "proxy_pid": 555,
+                "proxy_port": 8742,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registry._last_reap_at = 0.0
+    registry._reap_stale_sessions()
+
+    assert not lock_path.exists()
+
+
+def test_resolve_client_pid_prefers_ss_client_side_match(tmp_path: Path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    proc_tcp_path = tmp_path / "proc_tcp"
+    proc_tcp_path.write_text("", encoding="utf-8")
+
+    registry = SessionRegistry(
+        state_dir=tmp_path / "state",
+        proxy_port=8742,
+        proc_root=proc_root,
+        proc_tcp_path=proc_tcp_path,
+    )
+
+    ss_stdout = "\n".join(
+        [
+            "State Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+            'ESTAB 0 0 127.0.0.1:54000 127.0.0.1:8742 users:(("python",pid=4242,fd=3))',
+            'ESTAB 0 0 127.0.0.1:8742 127.0.0.1:54000 users:(("python",pid=777,fd=4))',
+        ]
+    )
+
+    def _fake_run(*args, **kwargs):
+        return CompletedProcess(args=args, returncode=0, stdout=ss_stdout, stderr="")
+
+    monkeypatch.setattr("tcp.proxy.session_registry.subprocess.run", _fake_run)
+
+    pid = registry._resolve_client_pid("127.0.0.1", 54000)
+
+    assert pid == 4242


### PR DESCRIPTION
## Summary
Implements the revised TCP-IMP-20 Phase 1 slice behind the existing shared proxy entrypoint on `127.0.0.1:8742`.

This keeps the current Claude launch flow intact while adding proxy-local per-session attribution, additive telemetry, per-session artifacts, and stale-session cleanup.

## What changed
- add `SessionRegistry` for shared-proxy session identity derived from the client-side loopback connection
- thread session context into request derivation so `workspace_path` follows the calling Claude client instead of the proxy process
- emit additive decision telemetry fields: `session_id`, `session_start_ts`, `proxy_pid`, `proxy_port`, `concurrent_sessions`
- dual-write decision rows to shared `decisions.jsonl` and per-session `sessions/<session_id>/decisions.jsonl`
- persist per-session `session.lock` and `requests.jsonl`
- reap stale sessions by PID liveness on the next request lookup
- add targeted tests for session telemetry, `ss`-based client PID resolution, and stale cleanup

## Validation
### Targeted unit coverage
- `.venv/bin/python -m pytest -q tests/unit/test_cc_proxy_session_registry.py tests/unit/test_cc_proxy_headers.py tests/unit/test_cc_proxy_response_tap.py`
- `.venv/bin/python -m py_compile tcp/proxy/session_registry.py tcp/proxy/cc_proxy.py`

### Broader proxy unit slice
- `.venv/bin/python -m pytest -q tests/unit/test_cc_proxy_*.py`

### Live validation
Validated with an isolated local proxy on `127.0.0.1:18752` and mock upstream on `127.0.0.1:18753`:
- requests from separate caller directories produced distinct `session_id` values
- shared `decisions.jsonl` rows included additive fields without breaking existing keys
- `workspace_path` matched caller directories, not the proxy cwd
- per-session `session.lock`, `requests.jsonl`, and `decisions.jsonl` were written
- stale lockfiles for exited clients were reaped on the next request lookup

## Scope notes
- shared fallback remains intact; no per-session port spawning or `ANTHROPIC_BASE_URL` injection
- cleanup is request-driven rather than timer-driven: dead sessions are reaped on the next lookup