### PR TITLE
feat(proxy): evidence-gated survivor reducer (TCP-IMP-23, shadow-only)

### DIFF
--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -58,7 +58,6 @@ from tcp.proxy.absence_language import (
 )
 from tcp.proxy.capability_resolution_gate import (
     CapabilityResolution,
-    extract_requested_capabilities,
     resolve_capabilities_for_request,
     resolution_to_log_record,
 )
@@ -411,10 +410,7 @@ def _description_similarity_proxy_telemetry(
         return base
     if mode == "deferred":
         return base
-    if (
-        pair_count > DESC_SIM_MAX_INLINE_PAIRS
-        or max_chars > DESC_SIM_MAX_INLINE_CHARS
-    ):
+    if pair_count > DESC_SIM_MAX_INLINE_PAIRS or max_chars > DESC_SIM_MAX_INLINE_CHARS:
         base["description_similarity_max_status"] = "skipped_budget"
         return base
 
@@ -794,9 +790,9 @@ def _process_tools_array(
     # Ranks active_survivors and produces a capped shortlist for telemetry.
     # Never mutates live_tools in this PR; never overrides the IMP-22
     # expected_tool_name derivation.  See tcp/proxy/survivor_reducer.py.
-    _crg_requested_capabilities = (
-        extract_requested_capabilities(prompt or "") if prompt else []
-    )
+    # Reuses CRG's already-extracted capability list so the regex pass over the
+    # prompt only happens once per request.
+    _crg_requested_capabilities = [r.requested_capability for r in _crg_resolutions]
     _tool_surface_for_reducer: dict[str, dict[str, Any]] = {}
     for _orig, _rec, _tier, _name in entries:
         if _rec is None:
@@ -880,10 +876,11 @@ class _ExpectedToolDerivation:
     TCP-IMP-22: expected_tool_name is only emitted when supported by defensible
     evidence. All other cases abstain and set expected_tool_abstain_reason.
     """
+
     expected_tool_name: str | None
-    derivation_source: str | None   # "single_survivor" | None
-    candidate_set_size: int         # survivor_count at derivation time
-    abstain_reason: str | None      # why expected_tool_name is None
+    derivation_source: str | None  # "single_survivor" | None
+    candidate_set_size: int  # survivor_count at derivation time
+    abstain_reason: str | None  # why expected_tool_name is None
 
 
 def _top_survivor_by_prompt_similarity(
@@ -1170,6 +1167,7 @@ def _check_denial_enforcement(
         SurfaceResult,
         _REQUIRED_SIX_SURFACES as _SIX,
     )
+
     resolutions: list[CapabilityResolution] = []
     for rec in crg_records:
         surface_results = tuple(
@@ -1472,7 +1470,12 @@ async def proxy_post_messages(request: Request) -> Response:
         # _tap["buf"] holds only the unparsed tail (incomplete last line) so that
         # _all_tools_from_sse_buf never rescans already-consumed bytes (O(n) total).
         # _tap["tool_sequence"] accumulates all tool calls until message_stop.
-        _tap: dict[str, Any] = {"buf": b"", "done": False, "tool_sequence": [], "text_buf": b""}
+        _tap: dict[str, Any] = {
+            "buf": b"",
+            "done": False,
+            "tool_sequence": [],
+            "text_buf": b"",
+        }
         first_byte_at: float | None = None
 
         async def body_iter() -> Any:

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -58,9 +58,11 @@ from tcp.proxy.absence_language import (
 )
 from tcp.proxy.capability_resolution_gate import (
     CapabilityResolution,
+    extract_requested_capabilities,
     resolve_capabilities_for_request,
     resolution_to_log_record,
 )
+from tcp.proxy.survivor_reducer import reduce_survivors
 from tcp.proxy.denial_enforcement import (
     denial_violation_record,
     enforce_denial_gate,
@@ -787,6 +789,46 @@ def _process_tools_array(
         meta["crg_false_denial_risk"] = any(
             r.status not in ("callable_now",) for r in _crg_resolutions
         )
+
+    # ── Stage 4.5: Evidence-gated survivor reducer (TCP-IMP-23, shadow-only)
+    # Ranks active_survivors and produces a capped shortlist for telemetry.
+    # Never mutates live_tools in this PR; never overrides the IMP-22
+    # expected_tool_name derivation.  See tcp/proxy/survivor_reducer.py.
+    _crg_requested_capabilities = (
+        extract_requested_capabilities(prompt or "") if prompt else []
+    )
+    _tool_surface_for_reducer: dict[str, dict[str, Any]] = {}
+    for _orig, _rec, _tier, _name in entries:
+        if _rec is None:
+            continue
+        if _rec.tool_name not in active_survivors:
+            continue
+        _tool_surface_for_reducer[_rec.tool_name] = {
+            "description": (
+                _orig.get("description", "") if isinstance(_orig, Mapping) else ""
+            ),
+            "capability_flags": _rec.capability_flags,
+            "surface_state": surface_state_by_tool.get(_rec.tool_name, STATE_ACTIVE),
+            "mcp_server": _extract_mcp_server(_rec.tool_name),
+        }
+    _reduction = reduce_survivors(
+        prompt=prompt or "",
+        survivor_names=frozenset(active_survivors),
+        tool_surface_by_name=_tool_surface_for_reducer,
+        required_capability_flags=tsel.required_capability_flags,
+        hard_capability_flags=tsel.hard_capability_flags,
+        heuristic_capability_flags=tsel.heuristic_capability_flags,
+        crg_requested_capabilities=_crg_requested_capabilities,
+        safety_floor_tools=_SAFETY_FLOOR_TOOLS,
+    )
+    meta["reducer_version"] = _reduction.reducer_version
+    meta["reducer_original_count"] = _reduction.original_count
+    meta["reducer_shortlisted_count"] = _reduction.shortlisted_count
+    meta["reducer_shortlisted_tools"] = list(_reduction.shortlisted_tools)
+    meta["reducer_ranked_tools"] = list(_reduction.ranked_tools)
+    meta["reducer_abstained"] = _reduction.abstained
+    meta["reducer_abstain_reason"] = _reduction.abstain_reason
+    meta["reducer_feature_summary"] = dict(_reduction.feature_summary)
 
     # ── Empty-set guardrail ──────────────────────────────────────────────
     if mode in ("live", "live-strict") and len(tools) > 0 and len(live_tools) == 0:

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -72,6 +72,12 @@ PROXY_STATE_DIR = Path.home() / ".tcp-shadow" / "proxy"
 MODE_PATH = PROXY_STATE_DIR / "mode"
 DECISIONS_LOG = PROXY_STATE_DIR / "decisions.jsonl"
 
+# Versioning: allows MT-21 analysis to distinguish rows logged before IMP-22
+# (where absent expected_tool_* fields mean "not recorded") from rows logged
+# after IMP-22 (where expected_tool_name=null means "system abstained").
+DECISION_LOG_SCHEMA: int = 2
+EXPECTED_TOOL_DERIVATION_ALGORITHM: str = "imp22.evidence_gated.v1"
+
 HOP_BY_HOP = frozenset(
     {
         "connection",
@@ -98,6 +104,23 @@ UPSTREAM_LIMITS = httpx.Limits(
 )
 UPSTREAM_RETRY_MAX_ATTEMPTS = 2
 SAFE_RETRY_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+DESC_SIM_MODE_ENV = "TCP_CC_DESC_SIM_MODE"
+DESC_SIM_VALID_MODES = frozenset({"deferred", "off", "inline"})
+DESC_SIM_DEFAULT_MODE = "deferred"
+DESC_SIM_METHOD = "difflib_v1"
+DESC_SIM_MAX_INLINE_PAIRS = int(
+    os.environ.get("TCP_CC_DESC_SIM_MAX_INLINE_PAIRS", "2000")
+)
+DESC_SIM_MAX_INLINE_CHARS = int(
+    os.environ.get("TCP_CC_DESC_SIM_MAX_INLINE_CHARS", "1024")
+)
+PROMPT_SIM_METHOD = "difflib_capped_v1"
+PROMPT_SIM_MAX_PROMPT_CHARS = int(
+    os.environ.get("TCP_CC_PROMPT_SIM_MAX_PROMPT_CHARS", "2048")
+)
+PROMPT_SIM_MAX_DESC_CHARS = int(
+    os.environ.get("TCP_CC_PROMPT_SIM_MAX_DESC_CHARS", "1024")
+)
 
 
 def _read_mode() -> str:
@@ -340,6 +363,62 @@ def _max_description_similarity_proxy(tools: list[Any]) -> float:
             if sim > max_sim:
                 max_sim = sim
     return max_sim
+
+
+def _description_similarity_mode() -> str:
+    mode = os.environ.get(DESC_SIM_MODE_ENV, DESC_SIM_DEFAULT_MODE).strip().lower()
+    return mode if mode in DESC_SIM_VALID_MODES else DESC_SIM_DEFAULT_MODE
+
+
+def _description_similarity_proxy_telemetry(
+    tools: list[Any],
+) -> dict[str, Any]:
+    """Bound live description-similarity telemetry.
+
+    The exact full-description metric is diagnostic only. It used to run in
+    live preflight for every request, where large tool surfaces turned the
+    O(n^2) SequenceMatcher loop into a seconds-long event-loop stall. Keep the
+    legacy numeric field present, but make expensive exact computation explicit
+    and opt-in.
+    """
+    descriptions = [
+        t.get("description", "")
+        for t in tools
+        if isinstance(t, Mapping) and t.get("description")
+    ]
+    tool_count = len(descriptions)
+    pair_count = tool_count * (tool_count - 1) // 2
+    max_chars = max((len(str(d)) for d in descriptions), default=0)
+    mode = _description_similarity_mode()
+
+    base: dict[str, Any] = {
+        "description_similarity_max": None,
+        "description_similarity_max_status": mode,
+        "description_similarity_max_method": DESC_SIM_METHOD,
+        "description_similarity_max_pair_count": pair_count,
+        "description_similarity_max_input_count": tool_count,
+        "description_similarity_max_max_chars": max_chars,
+    }
+
+    if tool_count < 2:
+        base["description_similarity_max"] = 0.0
+        base["description_similarity_max_status"] = "exact"
+        return base
+    if mode == "off":
+        base["description_similarity_max_status"] = "disabled"
+        return base
+    if mode == "deferred":
+        return base
+    if (
+        pair_count > DESC_SIM_MAX_INLINE_PAIRS
+        or max_chars > DESC_SIM_MAX_INLINE_CHARS
+    ):
+        base["description_similarity_max_status"] = "skipped_budget"
+        return base
+
+    base["description_similarity_max"] = _max_description_similarity_proxy(tools)
+    base["description_similarity_max_status"] = "exact"
+    return base
 
 
 def _process_tools_array(
@@ -663,7 +742,7 @@ def _process_tools_array(
         # first_tool_name / expected_tool_name / first_tool_correct are
         # populated by the response tap in proxy_post_messages after the
         # upstream response is observed.
-        "description_similarity_max": _max_description_similarity_proxy(
+        **_description_similarity_proxy_telemetry(
             [
                 orig
                 for (orig, rec, _tier, _name) in entries
@@ -672,7 +751,7 @@ def _process_tools_array(
         ),
         # TCP-IMP-17: prompt-similarity ranking — top survivor regardless of count.
         # Populated when the task prompt is non-empty and any survivors exist.
-        "top_survivor_by_similarity": _top_survivor_by_prompt_similarity(
+        **_top_survivor_by_prompt_similarity_telemetry(
             prompt,
             [
                 orig
@@ -795,6 +874,52 @@ def _top_survivor_by_prompt_similarity(
             best_score = score
             best_name = name if isinstance(name, str) else None
     return best_name
+
+
+def _top_survivor_by_prompt_similarity_telemetry(
+    prompt: str | None,
+    tools: list[Any],
+) -> dict[str, Any]:
+    """Bound prompt-to-tool similarity diagnostic work.
+
+    Claude Code requests can include large system-reminder text in the extracted
+    prompt. Running SequenceMatcher against full prompt and full tool
+    descriptions makes this diagnostic scale with prompt size and tool-surface
+    prose. Keep the legacy top_survivor_by_similarity field, but cap the text
+    that feeds the diagnostic.
+    """
+    base: dict[str, Any] = {
+        "top_survivor_by_similarity": None,
+        "top_survivor_by_similarity_status": "empty",
+        "top_survivor_by_similarity_method": PROMPT_SIM_METHOD,
+        "top_survivor_by_similarity_prompt_chars": len(prompt or ""),
+        "top_survivor_by_similarity_tool_count": len(tools),
+    }
+    if not prompt or not tools:
+        return base
+
+    prompt_capped = prompt[:PROMPT_SIM_MAX_PROMPT_CHARS].lower()
+    capped = len(prompt) > PROMPT_SIM_MAX_PROMPT_CHARS
+    best_name: str | None = None
+    best_score = -1.0
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            continue
+        name = tool.get("name", "") or ""
+        desc = tool.get("description", "") or ""
+        desc_s = desc if isinstance(desc, str) else str(desc)
+        if len(desc_s) > PROMPT_SIM_MAX_DESC_CHARS:
+            capped = True
+            desc_s = desc_s[:PROMPT_SIM_MAX_DESC_CHARS]
+        candidate = f"{name} {desc_s}".lower()
+        score = difflib.SequenceMatcher(None, prompt_capped, candidate).ratio()
+        if score > best_score:
+            best_score = score
+            best_name = name if isinstance(name, str) else None
+
+    base["top_survivor_by_similarity"] = best_name
+    base["top_survivor_by_similarity_status"] = "capped" if capped else "exact"
+    return base
 
 
 def _compute_expected_tool_name(meta: dict[str, Any] | None) -> _ExpectedToolDerivation:
@@ -1074,10 +1199,13 @@ def _write_decision_record(
             "ts": req_ts,
             "path": "/v1/messages",
             **meta,
+            "decision_log_schema": DECISION_LOG_SCHEMA,
             "first_tool_name": first_tool_name,
             "expected_tool_name": expected_tool_name,
             "expected_tool_derivation_source": derivation.derivation_source,
+            "expected_tool_derivation_algorithm": EXPECTED_TOOL_DERIVATION_ALGORITHM,
             "expected_tool_candidate_set_size": derivation.candidate_set_size,
+            "expected_tool_candidate_set_phase": "post_stage4_survivors",
             "expected_tool_abstain_reason": derivation.abstain_reason,
             "first_tool_correct": first_tool_correct,
             "tap_skipped": tap_skipped,

--- a/tcp/proxy/survivor_reducer.py
+++ b/tcp/proxy/survivor_reducer.py
@@ -38,6 +38,12 @@ import re
 from dataclasses import dataclass, field
 from typing import Mapping, Sequence
 
+# Reducer ranking reuses CRG's canonical capability → MCP server mapping so the
+# two modules cannot drift.  ``capability_resolution_gate`` does not import
+# anything from this module, so the dependency is acyclic.
+from tcp.proxy.capability_resolution_gate import (
+    _CAPABILITY_SERVERS as CAPABILITY_SERVERS,
+)
 
 REDUCER_VERSION: str = "imp23.evidence_gated_reducer.v1"
 
@@ -58,35 +64,6 @@ STATE_SUPPRESSED = "SUPPRESSED"
 
 ABSTAIN_NO_SURVIVORS = "no_survivors"
 ABSTAIN_NO_POSITIVE_EVIDENCE = "no_positive_evidence"
-
-# Capability identifier → MCP server family.  Mirrors the table in
-# ``tcp.proxy.capability_resolution_gate`` so the reducer can rank survivors by
-# CRG match without importing the full CRG module (avoids circular telemetry
-# coupling).  Kept narrow on purpose; missing capabilities yield no score.
-_CAPABILITY_SERVERS: dict[str, frozenset[str]] = {
-    "notion.search": frozenset({"notion-agents", "plugin_Notion_notion"}),
-    "notion.read": frozenset({"notion-agents", "plugin_Notion_notion"}),
-    "notion.write": frozenset({"notion-agents", "plugin_Notion_notion"}),
-    "github.code_search": frozenset({"github"}),
-    "github.pr": frozenset({"github"}),
-    "calendar.read": frozenset({"bay-view-graph"}),
-    "calendar.write": frozenset({"bay-view-graph"}),
-    "email.read": frozenset({"bay-view-graph"}),
-    "email.send": frozenset({"bay-view-graph"}),
-    "email.search": frozenset({"bay-view-graph"}),
-    "oracle.query": frozenset({"oracle-remote"}),
-    "web.fetch": frozenset({"fetch", "exa"}),
-    "web.search": frozenset({"exa", "nixos", "fetch"}),
-    "nix.package_search": frozenset({"nixos"}),
-    "filesystem.read": frozenset({"filesystem"}),
-    "filesystem.write": frozenset({"filesystem"}),
-    "git.log": frozenset({"git"}),
-    "git.diff": frozenset({"git"}),
-    "chatsearch.find": frozenset({"chatsearch"}),
-    "writing.rag": frozenset({"writing-rag"}),
-    "claude_projects.read": frozenset({"claude-projects"}),
-    "context7.docs": frozenset({"context7"}),
-}
 
 
 @dataclass(frozen=True)
@@ -176,7 +153,11 @@ def _popcount(value: int) -> int:
 
 
 def _coerce_state(raw: object) -> str:
-    if isinstance(raw, str) and raw.upper() in {STATE_ACTIVE, STATE_DEFERRED, STATE_SUPPRESSED}:
+    if isinstance(raw, str) and raw.upper() in {
+        STATE_ACTIVE,
+        STATE_DEFERRED,
+        STATE_SUPPRESSED,
+    }:
         return raw.upper()
     return STATE_ACTIVE
 
@@ -192,8 +173,26 @@ def _state_score(state: str) -> int:
 def _crg_servers_for_capabilities(capabilities: Sequence[str]) -> frozenset[str]:
     servers: set[str] = set()
     for cap in capabilities:
-        servers.update(_CAPABILITY_SERVERS.get(cap, frozenset()))
+        servers.update(CAPABILITY_SERVERS.get(cap, frozenset()))
     return frozenset(servers)
+
+
+def _word_boundary_present(needle: str, prompt_lc: str) -> bool:
+    """Return True iff ``needle`` (lowercased) appears in ``prompt_lc`` bounded
+    by non-alphanumeric characters on both sides.
+
+    Substring containment alone over-fires: the prompt ``"explain digital
+    signatures"`` would match an MCP server named ``git`` inside ``digital``,
+    producing a false positive-evidence verdict.  Word-boundary matching keeps
+    the exact-name feature true to its name.
+    """
+    if not needle or not prompt_lc:
+        return False
+    needle_lc = needle.lower()
+    pattern = re.compile(
+        r"(?:^|[^A-Za-z0-9])" + re.escape(needle_lc) + r"(?:[^A-Za-z0-9]|$)"
+    )
+    return bool(pattern.search(prompt_lc))
 
 
 # ── Public API ─────────────────────────────────────────────────────────────────
@@ -247,6 +246,8 @@ def reduce_survivors(
         to mutate ``live_tools`` in this PR.
     """
     if not survivor_names:
+        # Same key set as the populated path so downstream telemetry consumers
+        # see a stable schema regardless of abstain reason.
         return SurvivorReduction(
             original_count=0,
             shortlisted_count=0,
@@ -266,6 +267,10 @@ def reduce_survivors(
                 "safety_floor_preserved": 0,
                 "positive_evidence_tools": 0,
                 "crg_capabilities": list(crg_requested_capabilities),
+                "heuristic_capability_flags": int(heuristic_capability_flags),
+                "hard_capability_flags": int(hard_capability_flags),
+                "required_capability_flags": int(required_capability_flags),
+                "max_shortlist": int(max_shortlist),
             },
         )
 
@@ -299,12 +304,18 @@ def reduce_survivors(
         if not isinstance(mcp_server, str) or not mcp_server:
             mcp_server = _extract_mcp_server(name)
 
-        # Feature 1: exact tool name or server name appears in the prompt.
+        # Feature 1: exact tool name or server name appears in the prompt,
+        # bounded by non-alphanumeric characters so incidental substrings
+        # (e.g. "git" inside "digital") do not register as evidence.
         feat_exact_name = False
         if prompt_lc:
-            if name and name.lower() in prompt_lc:
+            if name and _word_boundary_present(name, prompt_lc):
                 feat_exact_name = True
-            elif isinstance(mcp_server, str) and mcp_server and mcp_server.lower() in prompt_lc:
+            elif (
+                isinstance(mcp_server, str)
+                and mcp_server
+                and _word_boundary_present(mcp_server, prompt_lc)
+            ):
                 feat_exact_name = True
 
         # Feature 2: CRG capability family match by MCP server.
@@ -320,11 +331,13 @@ def reduce_survivors(
             SCORE_HEURISTIC_OVERLAP_CAP,
         )
 
-        # Feature 4: command/name lexical match — any tool token appears in prompt.
+        # Feature 4: command/name lexical match — any tool token appears in the
+        # prompt as a whole word.  Word-boundary checking keeps short tokens
+        # like ``git`` from matching inside ``digital``.
         feat_lexical_name = False
         if prompt_lc:
             for token in _lexical_tokens(name):
-                if token in prompt_lc:
+                if _word_boundary_present(token, prompt_lc):
                     feat_lexical_name = True
                     break
 

--- a/tcp/proxy/survivor_reducer.py
+++ b/tcp/proxy/survivor_reducer.py
@@ -1,0 +1,435 @@
+"""Evidence-gated Stage 4.5 survivor reducer (TCP-IMP-23, shadow-only).
+
+Post-IMP-22 analysis showed that Stage 1-4 of the cc_proxy gating pipeline never
+narrows ``active_survivors`` to a single tool: the modal operating point is 196
+survivors and the maximum observed is 336.  IMP-22 correctly abstains from
+emitting ``expected_tool_name`` in that regime, but the proxy lacks any bounded
+ranking + shortlisting step that records *which* of those survivors are most
+plausibly relevant to the request.
+
+This module supplies that step.  ``reduce_survivors`` ranks ``active_survivors``
+using transparent, evidence-bearing features and produces a capped shortlist.
+It is **shadow-only** in this PR: callers must not use the shortlist to mutate
+the live tool list sent upstream.  The shortlist is recorded in decisions.jsonl
+for offline replay against the IMP-23 acceptance metrics.
+
+Design constraints (from spec):
+
+  1. Never drop ``safety_floor_tools`` from the shortlist when present in
+     survivors.
+  2. Never hard-prune solely on ``heuristic_capability_flags`` — those flags
+     contribute to *ranking* but cannot, on their own, determine emit/abstain.
+  3. Score with multiple transparent features:
+        - exact tool/server name mention in prompt
+        - CRG capability family match
+        - heuristic_capability_flags overlap with the tool's flags
+        - command/name lexical match
+        - pack state ACTIVE > DEFERRED > SUPPRESSED
+  4. If no positive evidence exists, abstain — do not produce a misleading
+     shortlist.  The original survivor count is preserved in telemetry.
+  5. If positive evidence exists, emit a shortlist capped at ``max_shortlist``,
+     with the safety floor always preserved (its members may push the result
+     above the cap rather than displace one another).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+
+REDUCER_VERSION: str = "imp23.evidence_gated_reducer.v1"
+
+# Transparent integer score weights.  Kept as module-level constants so a future
+# spec can tune them with explicit traceability rather than buried magic numbers.
+SCORE_EXACT_NAME: int = 10
+SCORE_CRG_FAMILY: int = 6
+SCORE_LEXICAL_NAME: int = 3
+SCORE_HEURISTIC_OVERLAP_PER_BIT: int = 2
+SCORE_HEURISTIC_OVERLAP_CAP: int = 6
+SCORE_STATE_ACTIVE: int = 2
+SCORE_STATE_DEFERRED: int = 1
+SCORE_STATE_SUPPRESSED: int = 0
+
+STATE_ACTIVE = "ACTIVE"
+STATE_DEFERRED = "DEFERRED"
+STATE_SUPPRESSED = "SUPPRESSED"
+
+ABSTAIN_NO_SURVIVORS = "no_survivors"
+ABSTAIN_NO_POSITIVE_EVIDENCE = "no_positive_evidence"
+
+# Capability identifier → MCP server family.  Mirrors the table in
+# ``tcp.proxy.capability_resolution_gate`` so the reducer can rank survivors by
+# CRG match without importing the full CRG module (avoids circular telemetry
+# coupling).  Kept narrow on purpose; missing capabilities yield no score.
+_CAPABILITY_SERVERS: dict[str, frozenset[str]] = {
+    "notion.search": frozenset({"notion-agents", "plugin_Notion_notion"}),
+    "notion.read": frozenset({"notion-agents", "plugin_Notion_notion"}),
+    "notion.write": frozenset({"notion-agents", "plugin_Notion_notion"}),
+    "github.code_search": frozenset({"github"}),
+    "github.pr": frozenset({"github"}),
+    "calendar.read": frozenset({"bay-view-graph"}),
+    "calendar.write": frozenset({"bay-view-graph"}),
+    "email.read": frozenset({"bay-view-graph"}),
+    "email.send": frozenset({"bay-view-graph"}),
+    "email.search": frozenset({"bay-view-graph"}),
+    "oracle.query": frozenset({"oracle-remote"}),
+    "web.fetch": frozenset({"fetch", "exa"}),
+    "web.search": frozenset({"exa", "nixos", "fetch"}),
+    "nix.package_search": frozenset({"nixos"}),
+    "filesystem.read": frozenset({"filesystem"}),
+    "filesystem.write": frozenset({"filesystem"}),
+    "git.log": frozenset({"git"}),
+    "git.diff": frozenset({"git"}),
+    "chatsearch.find": frozenset({"chatsearch"}),
+    "writing.rag": frozenset({"writing-rag"}),
+    "claude_projects.read": frozenset({"claude-projects"}),
+    "context7.docs": frozenset({"context7"}),
+}
+
+
+@dataclass(frozen=True)
+class SurvivorReduction:
+    """Outcome of one reducer pass.
+
+    Attributes:
+        original_count:        Survivor count entering the reducer.
+        shortlisted_count:     Length of ``shortlisted_tools``.  When abstaining,
+                               this is 0 even though the survivor set is intact.
+        shortlisted_tools:     Tools the reducer would propose in shadow mode.
+                               Always preserves any safety-floor entries that
+                               were in the input survivor set.
+        ranked_tools:          All survivors ordered by descending score.  Lets
+                               replay scripts inspect ranking without needing
+                               feature reconstruction.
+        abstained:             True when no survivor met positive-evidence
+                               criteria.  When True, ``shortlisted_tools`` is
+                               empty and the proxy must record the original
+                               survivor set in the existing
+                               ``survivor_names_sorted`` field for downstream
+                               analysis.
+        abstain_reason:        Stable string identifier for the abstention.
+        reducer_version:       Algorithm version string written into telemetry.
+        feature_summary:       Aggregate signal counts for offline diagnosis.
+    """
+
+    original_count: int
+    shortlisted_count: int
+    shortlisted_tools: tuple[str, ...]
+    ranked_tools: tuple[str, ...]
+    abstained: bool
+    abstain_reason: str | None
+    reducer_version: str
+    feature_summary: dict[str, object] = field(default_factory=dict)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+_TOKEN_SPLIT_RE = re.compile(r"[^A-Za-z0-9]+")
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _extract_mcp_server(tool_name: str) -> str | None:
+    if not tool_name.startswith("mcp__"):
+        return None
+    parts = tool_name.split("__")
+    if len(parts) < 2:
+        return None
+    server = parts[1].strip()
+    return server or None
+
+
+def _lexical_tokens(tool_name: str) -> frozenset[str]:
+    """Return lowercased tokens that lexically identify the tool.
+
+    For built-ins, splits CamelCase and snake_case into individual tokens.
+    For MCP tools, includes the server name and the action portion's tokens.
+    All tokens are at least 3 characters long; shorter ones make the lexical
+    score noisy on common words like ``rm`` or ``ls``.
+    """
+    if not tool_name:
+        return frozenset()
+    raw_pieces: list[str] = []
+    if tool_name.startswith("mcp__"):
+        parts = tool_name.split("__")
+        if len(parts) >= 2:
+            raw_pieces.append(parts[1])  # server
+        if len(parts) >= 3:
+            raw_pieces.extend(parts[2:])  # action segments
+    else:
+        raw_pieces.append(tool_name)
+    tokens: set[str] = set()
+    for piece in raw_pieces:
+        for chunk in _TOKEN_SPLIT_RE.split(piece):
+            if not chunk:
+                continue
+            for sub in _CAMEL_SPLIT_RE.split(chunk):
+                if len(sub) >= 3:
+                    tokens.add(sub.lower())
+    return frozenset(tokens)
+
+
+def _popcount(value: int) -> int:
+    return bin(value & 0xFFFFFFFFFFFFFFFF).count("1") if value else 0
+
+
+def _coerce_state(raw: object) -> str:
+    if isinstance(raw, str) and raw.upper() in {STATE_ACTIVE, STATE_DEFERRED, STATE_SUPPRESSED}:
+        return raw.upper()
+    return STATE_ACTIVE
+
+
+def _state_score(state: str) -> int:
+    if state == STATE_ACTIVE:
+        return SCORE_STATE_ACTIVE
+    if state == STATE_DEFERRED:
+        return SCORE_STATE_DEFERRED
+    return SCORE_STATE_SUPPRESSED
+
+
+def _crg_servers_for_capabilities(capabilities: Sequence[str]) -> frozenset[str]:
+    servers: set[str] = set()
+    for cap in capabilities:
+        servers.update(_CAPABILITY_SERVERS.get(cap, frozenset()))
+    return frozenset(servers)
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def reduce_survivors(
+    prompt: str,
+    survivor_names: frozenset[str],
+    tool_surface_by_name: Mapping[str, Mapping[str, object]],
+    required_capability_flags: int,
+    hard_capability_flags: int,
+    heuristic_capability_flags: int,
+    crg_requested_capabilities: Sequence[str],
+    safety_floor_tools: frozenset[str],
+    max_shortlist: int = 20,
+) -> SurvivorReduction:
+    """Rank and shortlist surviving tools using transparent feature scoring.
+
+    The reducer is deterministic and pure: same inputs always produce the same
+    output.  See module docstring for invariants.
+
+    Parameters:
+        prompt: The extracted task prompt.  May be empty; when empty, the
+            lexical/exact-name features cannot fire and the reducer typically
+            abstains unless CRG capabilities supply positive evidence.
+        survivor_names: Tools that passed Stages 1-4 (post-safety-floor).
+        tool_surface_by_name: Per-tool metadata.  Each value may include
+            ``description`` (str), ``capability_flags`` (int),
+            ``surface_state`` (one of ACTIVE/DEFERRED/SUPPRESSED), and
+            ``mcp_server`` (str|None).  Missing keys default to safe values.
+        required_capability_flags: Aggregate capability flags the prompt
+            implies (heuristic + hard).  Used for telemetry only.
+        hard_capability_flags: Environment-derived capability flags.  Used for
+            telemetry only.
+        heuristic_capability_flags: Prompt-derived capability flags.  Allowed to
+            *rank* survivors (overlap adds to score) but cannot, on its own,
+            determine emit/abstain — see invariant 2.
+        crg_requested_capabilities: Capability identifiers extracted from the
+            prompt by ``capability_resolution_gate.extract_requested_capabilities``
+            (or the equivalent).  When a survivor's MCP server is in any of the
+            corresponding capability families, that survivor scores positive
+            evidence.
+        safety_floor_tools: Tool names guaranteed to remain in the shortlist
+            when present in ``survivor_names``.
+        max_shortlist: Soft cap on shortlist size.  Safety-floor entries are
+            always preserved even if they push the final count above the cap.
+
+    Returns:
+        A ``SurvivorReduction`` describing the shortlist, ranking, and
+        feature aggregates.  Shadow-only: callers must not use the shortlist
+        to mutate ``live_tools`` in this PR.
+    """
+    if not survivor_names:
+        return SurvivorReduction(
+            original_count=0,
+            shortlisted_count=0,
+            shortlisted_tools=(),
+            ranked_tools=(),
+            abstained=True,
+            abstain_reason=ABSTAIN_NO_SURVIVORS,
+            reducer_version=REDUCER_VERSION,
+            feature_summary={
+                "exact_name_matches": 0,
+                "crg_family_matches": 0,
+                "lexical_name_matches": 0,
+                "heuristic_flag_matches": 0,
+                "state_active": 0,
+                "state_deferred": 0,
+                "state_suppressed": 0,
+                "safety_floor_preserved": 0,
+                "positive_evidence_tools": 0,
+                "crg_capabilities": list(crg_requested_capabilities),
+            },
+        )
+
+    prompt_lc = (prompt or "").lower()
+    crg_servers = _crg_servers_for_capabilities(crg_requested_capabilities)
+
+    # Per-tool feature evaluation.  Sorted survivors so iteration order — and
+    # therefore the tie-breaking for equally scored tools — is deterministic.
+    sorted_survivors = sorted(survivor_names)
+
+    scored: list[tuple[int, str, dict[str, bool]]] = []
+    aggregates = {
+        "exact_name_matches": 0,
+        "crg_family_matches": 0,
+        "lexical_name_matches": 0,
+        "heuristic_flag_matches": 0,
+        "state_active": 0,
+        "state_deferred": 0,
+        "state_suppressed": 0,
+    }
+
+    for name in sorted_survivors:
+        surface = tool_surface_by_name.get(name) or {}
+        capability_flags_raw = surface.get("capability_flags", 0)
+        try:
+            tool_flags = int(capability_flags_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            tool_flags = 0
+        state = _coerce_state(surface.get("surface_state"))
+        mcp_server = surface.get("mcp_server")
+        if not isinstance(mcp_server, str) or not mcp_server:
+            mcp_server = _extract_mcp_server(name)
+
+        # Feature 1: exact tool name or server name appears in the prompt.
+        feat_exact_name = False
+        if prompt_lc:
+            if name and name.lower() in prompt_lc:
+                feat_exact_name = True
+            elif isinstance(mcp_server, str) and mcp_server and mcp_server.lower() in prompt_lc:
+                feat_exact_name = True
+
+        # Feature 2: CRG capability family match by MCP server.
+        feat_crg_family = bool(
+            isinstance(mcp_server, str) and mcp_server and mcp_server in crg_servers
+        )
+
+        # Feature 3: heuristic capability flags overlap.
+        overlap_bits = _popcount(tool_flags & heuristic_capability_flags)
+        feat_heuristic = overlap_bits > 0
+        heuristic_score = min(
+            overlap_bits * SCORE_HEURISTIC_OVERLAP_PER_BIT,
+            SCORE_HEURISTIC_OVERLAP_CAP,
+        )
+
+        # Feature 4: command/name lexical match — any tool token appears in prompt.
+        feat_lexical_name = False
+        if prompt_lc:
+            for token in _lexical_tokens(name):
+                if token in prompt_lc:
+                    feat_lexical_name = True
+                    break
+
+        # Feature 5: pack state preference.
+        state_score = _state_score(state)
+
+        score = (
+            (SCORE_EXACT_NAME if feat_exact_name else 0)
+            + (SCORE_CRG_FAMILY if feat_crg_family else 0)
+            + (SCORE_LEXICAL_NAME if feat_lexical_name else 0)
+            + heuristic_score
+            + state_score
+        )
+
+        if feat_exact_name:
+            aggregates["exact_name_matches"] += 1
+        if feat_crg_family:
+            aggregates["crg_family_matches"] += 1
+        if feat_lexical_name:
+            aggregates["lexical_name_matches"] += 1
+        if feat_heuristic:
+            aggregates["heuristic_flag_matches"] += 1
+        if state == STATE_ACTIVE:
+            aggregates["state_active"] += 1
+        elif state == STATE_DEFERRED:
+            aggregates["state_deferred"] += 1
+        else:
+            aggregates["state_suppressed"] += 1
+
+        scored.append(
+            (
+                score,
+                name,
+                {
+                    "exact_name": feat_exact_name,
+                    "crg_family": feat_crg_family,
+                    "lexical_name": feat_lexical_name,
+                    "heuristic_flags": feat_heuristic,
+                },
+            )
+        )
+
+    # Ranked ordering: descending score, then ascending name (stable).
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    ranked_tools = tuple(name for _, name, _ in scored)
+
+    # Positive-evidence detection.  Heuristic flags alone do NOT count.
+    positive_evidence_tools = [
+        name
+        for _, name, feats in scored
+        if feats["exact_name"] or feats["crg_family"] or feats["lexical_name"]
+    ]
+
+    aggregates["safety_floor_preserved"] = sum(
+        1 for name in survivor_names if name in safety_floor_tools
+    )
+    aggregates["positive_evidence_tools"] = len(positive_evidence_tools)
+
+    feature_summary: dict[str, object] = dict(aggregates)
+    feature_summary["crg_capabilities"] = list(crg_requested_capabilities)
+    feature_summary["heuristic_capability_flags"] = int(heuristic_capability_flags)
+    feature_summary["hard_capability_flags"] = int(hard_capability_flags)
+    feature_summary["required_capability_flags"] = int(required_capability_flags)
+    feature_summary["max_shortlist"] = int(max_shortlist)
+
+    if not positive_evidence_tools:
+        # No survivor cleared the positive-evidence bar.  Abstain so callers do
+        # not assemble a misleading shortlist.  Telemetry preserves the original
+        # set via the proxy's existing ``survivor_names_sorted`` field.
+        return SurvivorReduction(
+            original_count=len(survivor_names),
+            shortlisted_count=0,
+            shortlisted_tools=(),
+            ranked_tools=ranked_tools,
+            abstained=True,
+            abstain_reason=ABSTAIN_NO_POSITIVE_EVIDENCE,
+            reducer_version=REDUCER_VERSION,
+            feature_summary=feature_summary,
+        )
+
+    # Build the shortlist.  Order: positive-evidence tools by descending score,
+    # capped at max_shortlist; then unioned with safety-floor survivors (which
+    # may push the total above the cap rather than displace evidence-positive
+    # tools).
+    capped: list[str] = []
+    for _, name, feats in scored:
+        if feats["exact_name"] or feats["crg_family"] or feats["lexical_name"]:
+            capped.append(name)
+            if len(capped) >= max_shortlist:
+                break
+
+    shortlist: list[str] = list(capped)
+    shortlist_set = set(shortlist)
+    for name in sorted(survivor_names & safety_floor_tools):
+        if name not in shortlist_set:
+            shortlist.append(name)
+            shortlist_set.add(name)
+
+    return SurvivorReduction(
+        original_count=len(survivor_names),
+        shortlisted_count=len(shortlist),
+        shortlisted_tools=tuple(shortlist),
+        ranked_tools=ranked_tools,
+        abstained=False,
+        abstain_reason=None,
+        reducer_version=REDUCER_VERSION,
+        feature_summary=feature_summary,
+    )

--- a/tests/unit/test_cc_proxy_decisions_meta.py
+++ b/tests/unit/test_cc_proxy_decisions_meta.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from tcp.proxy.cc_proxy import _process_tools_array
+import difflib
+from unittest.mock import patch
+
+from tcp.proxy.cc_proxy import (
+    DECISION_LOG_SCHEMA,
+    EXPECTED_TOOL_DERIVATION_ALGORITHM,
+    _compute_expected_tool_name,
+    _process_tools_array,
+    _write_decision_record,
+)
 
 
 def test_decisions_meta_includes_full_tool_count_and_survivor_count() -> None:
@@ -50,3 +59,187 @@ def test_decisions_meta_includes_replay_freshness_fields() -> None:
     assert meta["pack_manifest_source"]
     assert meta["pack_manifest_hash"]
     assert "hard_allowed_servers" in meta
+
+
+def test_description_similarity_defaults_to_deferred(monkeypatch) -> None:
+    monkeypatch.delenv("TCP_CC_DESC_SIM_MODE", raising=False)
+    tools = [
+        {
+            "name": f"Tool{i}",
+            "description": "similar description " * 20,
+            "input_schema": {"type": "object"},
+        }
+        for i in range(10)
+    ]
+    _, meta = _process_tools_array(tools, {"messages": []}, "shadow")
+    assert meta["description_similarity_max"] is None
+    assert meta["description_similarity_max_status"] == "deferred"
+    assert meta["description_similarity_max_method"] == "difflib_v1"
+    assert meta["description_similarity_max_pair_count"] == 45
+    assert meta["description_similarity_max_input_count"] == 10
+
+
+def test_description_similarity_inline_exact_for_small_inputs(monkeypatch) -> None:
+    monkeypatch.setenv("TCP_CC_DESC_SIM_MODE", "inline")
+    tools = [
+        {
+            "name": "ToolA",
+            "description": "read a file from disk",
+            "input_schema": {"type": "object"},
+        },
+        {
+            "name": "ToolB",
+            "description": "read a file from disk safely",
+            "input_schema": {"type": "object"},
+        },
+    ]
+    _, meta = _process_tools_array(tools, {"messages": []}, "shadow")
+    assert isinstance(meta["description_similarity_max"], float)
+    assert 0.0 <= meta["description_similarity_max"] <= 1.0
+    assert meta["description_similarity_max_status"] == "exact"
+
+
+def test_description_similarity_inline_skips_large_budget(monkeypatch) -> None:
+    monkeypatch.setenv("TCP_CC_DESC_SIM_MODE", "inline")
+
+    def fail_sequence_matcher(*args, **kwargs):
+        raise AssertionError("full pairwise SequenceMatcher should be budget-skipped")
+
+    monkeypatch.setattr(difflib, "SequenceMatcher", fail_sequence_matcher)
+    tools = [
+        {
+            "name": f"Tool{i}",
+            "description": "long repeated description " * 80,
+            "input_schema": {"type": "object"},
+        }
+        for i in range(100)
+    ]
+    _, meta = _process_tools_array(tools, {"messages": []}, "shadow")
+    assert meta["description_similarity_max"] is None
+    assert meta["description_similarity_max_status"] == "skipped_budget"
+    assert meta["description_similarity_max_pair_count"] == 4950
+
+
+def test_prompt_similarity_caps_large_prompt_and_descriptions() -> None:
+    prompt = "system reminder " * 1000 + " please read the project status"
+    tools = [
+        {
+            "name": f"Tool{i}",
+            "description": "long repeated description " * 500,
+            "input_schema": {"type": "object"},
+        }
+        for i in range(50)
+    ]
+    _, meta = _process_tools_array(
+        tools,
+        {"messages": [{"role": "user", "content": prompt}]},
+        "shadow",
+    )
+    assert "top_survivor_by_similarity" in meta
+    assert meta["top_survivor_by_similarity_status"] == "capped"
+    assert meta["top_survivor_by_similarity_method"] == "difflib_capped_v1"
+    assert meta["top_survivor_by_similarity_prompt_chars"] == len(prompt)
+    assert meta["top_survivor_by_similarity_tool_count"] == 50
+
+
+# ── TCP-IMP-23: decision log schema versioning and derivation invariants ───────
+# Forge invariants: these tests prevent MT-21 from running on semantically false
+# data (Counterexample Forge session, 2026-05-09).
+
+
+def test_decision_log_schema_is_present_in_written_record() -> None:
+    """decision_log_schema must be present on every written record (IMP-23)."""
+    captured: list[dict] = []
+    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
+        _write_decision_record(0.0, {"survivor_count": 0, "survivor_names_sorted": []}, None)
+    assert len(captured) == 1
+    assert captured[0]["decision_log_schema"] == DECISION_LOG_SCHEMA
+    assert isinstance(captured[0]["decision_log_schema"], int)
+
+
+def test_derivation_algorithm_version_is_present_in_written_record() -> None:
+    """expected_tool_derivation_algorithm must be present on every written record."""
+    captured: list[dict] = []
+    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
+        _write_decision_record(0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, None)
+    assert captured[0]["expected_tool_derivation_algorithm"] == EXPECTED_TOOL_DERIVATION_ALGORITHM
+
+
+def test_derivation_single_survivor_emits_with_source() -> None:
+    """Single survivor → expected_tool_name emitted, source='single_survivor', no abstain."""
+    result = _compute_expected_tool_name({"survivor_count": 1, "survivor_names_sorted": ["Read"]})
+    assert result.expected_tool_name == "Read"
+    assert result.derivation_source == "single_survivor"
+    assert result.candidate_set_size == 1
+    assert result.abstain_reason is None
+
+
+def test_derivation_multiple_survivors_abstains() -> None:
+    """Multiple survivors → abstains with ambiguous_N_survivors, no source."""
+    result = _compute_expected_tool_name(
+        {"survivor_count": 3, "survivor_names_sorted": ["Read", "Bash", "Grep"]}
+    )
+    assert result.expected_tool_name is None
+    assert result.derivation_source is None
+    assert result.abstain_reason == "ambiguous_3_survivors"
+
+
+def test_derivation_no_survivors_abstains() -> None:
+    """Zero survivors → abstains with 'no_survivors'."""
+    result = _compute_expected_tool_name({"survivor_count": 0, "survivor_names_sorted": []})
+    assert result.expected_tool_name is None
+    assert result.abstain_reason == "no_survivors"
+
+
+def test_derivation_count_list_mismatch_abstains() -> None:
+    """count=1 but empty survivors list → abstains with 'count_list_mismatch'."""
+    result = _compute_expected_tool_name({"survivor_count": 1, "survivor_names_sorted": []})
+    assert result.expected_tool_name is None
+    assert result.abstain_reason == "count_list_mismatch"
+
+
+def test_derivation_no_meta_abstains() -> None:
+    """None meta → abstains with 'no_meta' (not raised, not masked)."""
+    result = _compute_expected_tool_name(None)
+    assert result.expected_tool_name is None
+    assert result.abstain_reason == "no_meta"
+
+
+def test_derivation_source_null_iff_name_null() -> None:
+    """Forge invariant: derivation_source is null iff expected_tool_name is null."""
+    cases = [
+        {"survivor_count": 1, "survivor_names_sorted": ["Read"]},
+        {"survivor_count": 0, "survivor_names_sorted": []},
+        {"survivor_count": 2, "survivor_names_sorted": ["Read", "Bash"]},
+        {"survivor_count": 1, "survivor_names_sorted": []},
+    ]
+    for meta in cases:
+        r = _compute_expected_tool_name(meta)
+        if r.expected_tool_name is None:
+            assert r.derivation_source is None, f"source should be null when name is null: {meta}"
+        else:
+            assert r.derivation_source is not None, f"source must be set when name is emitted: {meta}"
+
+
+def test_derivation_abstain_reason_null_iff_emitted() -> None:
+    """Forge invariant: abstain_reason is null iff expected_tool_name is not null."""
+    cases = [
+        {"survivor_count": 1, "survivor_names_sorted": ["Bash"]},
+        {"survivor_count": 0, "survivor_names_sorted": []},
+        {"survivor_count": 4, "survivor_names_sorted": ["A", "B", "C", "D"]},
+        None,
+    ]
+    for meta in cases:
+        r = _compute_expected_tool_name(meta)
+        if r.expected_tool_name is not None:
+            assert r.abstain_reason is None, f"abstain_reason must be null when tool emitted: {meta}"
+        else:
+            assert r.abstain_reason is not None, f"abstain_reason required when abstained: {meta}"
+
+
+def test_decision_log_schema_candidate_set_phase_present() -> None:
+    """expected_tool_candidate_set_phase must be logged to disambiguate pipeline stage."""
+    captured: list[dict] = []
+    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
+        _write_decision_record(0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, "Read")
+    assert captured[0]["expected_tool_candidate_set_phase"] == "post_stage4_survivors"

--- a/tests/unit/test_cc_proxy_decisions_meta.py
+++ b/tests/unit/test_cc_proxy_decisions_meta.py
@@ -150,8 +150,12 @@ def test_prompt_similarity_caps_large_prompt_and_descriptions() -> None:
 def test_decision_log_schema_is_present_in_written_record() -> None:
     """decision_log_schema must be present on every written record (IMP-23)."""
     captured: list[dict] = []
-    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
-        _write_decision_record(0.0, {"survivor_count": 0, "survivor_names_sorted": []}, None)
+    with patch(
+        "tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)
+    ):
+        _write_decision_record(
+            0.0, {"survivor_count": 0, "survivor_names_sorted": []}, None
+        )
     assert len(captured) == 1
     assert captured[0]["decision_log_schema"] == DECISION_LOG_SCHEMA
     assert isinstance(captured[0]["decision_log_schema"], int)
@@ -160,14 +164,23 @@ def test_decision_log_schema_is_present_in_written_record() -> None:
 def test_derivation_algorithm_version_is_present_in_written_record() -> None:
     """expected_tool_derivation_algorithm must be present on every written record."""
     captured: list[dict] = []
-    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
-        _write_decision_record(0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, None)
-    assert captured[0]["expected_tool_derivation_algorithm"] == EXPECTED_TOOL_DERIVATION_ALGORITHM
+    with patch(
+        "tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)
+    ):
+        _write_decision_record(
+            0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, None
+        )
+    assert (
+        captured[0]["expected_tool_derivation_algorithm"]
+        == EXPECTED_TOOL_DERIVATION_ALGORITHM
+    )
 
 
 def test_derivation_single_survivor_emits_with_source() -> None:
     """Single survivor → expected_tool_name emitted, source='single_survivor', no abstain."""
-    result = _compute_expected_tool_name({"survivor_count": 1, "survivor_names_sorted": ["Read"]})
+    result = _compute_expected_tool_name(
+        {"survivor_count": 1, "survivor_names_sorted": ["Read"]}
+    )
     assert result.expected_tool_name == "Read"
     assert result.derivation_source == "single_survivor"
     assert result.candidate_set_size == 1
@@ -186,14 +199,18 @@ def test_derivation_multiple_survivors_abstains() -> None:
 
 def test_derivation_no_survivors_abstains() -> None:
     """Zero survivors → abstains with 'no_survivors'."""
-    result = _compute_expected_tool_name({"survivor_count": 0, "survivor_names_sorted": []})
+    result = _compute_expected_tool_name(
+        {"survivor_count": 0, "survivor_names_sorted": []}
+    )
     assert result.expected_tool_name is None
     assert result.abstain_reason == "no_survivors"
 
 
 def test_derivation_count_list_mismatch_abstains() -> None:
     """count=1 but empty survivors list → abstains with 'count_list_mismatch'."""
-    result = _compute_expected_tool_name({"survivor_count": 1, "survivor_names_sorted": []})
+    result = _compute_expected_tool_name(
+        {"survivor_count": 1, "survivor_names_sorted": []}
+    )
     assert result.expected_tool_name is None
     assert result.abstain_reason == "count_list_mismatch"
 
@@ -216,9 +233,13 @@ def test_derivation_source_null_iff_name_null() -> None:
     for meta in cases:
         r = _compute_expected_tool_name(meta)
         if r.expected_tool_name is None:
-            assert r.derivation_source is None, f"source should be null when name is null: {meta}"
+            assert (
+                r.derivation_source is None
+            ), f"source should be null when name is null: {meta}"
         else:
-            assert r.derivation_source is not None, f"source must be set when name is emitted: {meta}"
+            assert (
+                r.derivation_source is not None
+            ), f"source must be set when name is emitted: {meta}"
 
 
 def test_derivation_abstain_reason_null_iff_emitted() -> None:
@@ -232,14 +253,22 @@ def test_derivation_abstain_reason_null_iff_emitted() -> None:
     for meta in cases:
         r = _compute_expected_tool_name(meta)
         if r.expected_tool_name is not None:
-            assert r.abstain_reason is None, f"abstain_reason must be null when tool emitted: {meta}"
+            assert (
+                r.abstain_reason is None
+            ), f"abstain_reason must be null when tool emitted: {meta}"
         else:
-            assert r.abstain_reason is not None, f"abstain_reason required when abstained: {meta}"
+            assert (
+                r.abstain_reason is not None
+            ), f"abstain_reason required when abstained: {meta}"
 
 
 def test_decision_log_schema_candidate_set_phase_present() -> None:
     """expected_tool_candidate_set_phase must be logged to disambiguate pipeline stage."""
     captured: list[dict] = []
-    with patch("tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)):
-        _write_decision_record(0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, "Read")
+    with patch(
+        "tcp.proxy.cc_proxy._append_jsonl", lambda _path, rec: captured.append(rec)
+    ):
+        _write_decision_record(
+            0.0, {"survivor_count": 1, "survivor_names_sorted": ["Read"]}, "Read"
+        )
     assert captured[0]["expected_tool_candidate_set_phase"] == "post_stage4_survivors"

--- a/tests/unit/test_survivor_reducer.py
+++ b/tests/unit/test_survivor_reducer.py
@@ -1,0 +1,475 @@
+"""Unit tests for the evidence-gated Stage 4.5 survivor reducer (TCP-IMP-23)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tcp.proxy.survivor_reducer import (
+    ABSTAIN_NO_POSITIVE_EVIDENCE,
+    ABSTAIN_NO_SURVIVORS,
+    REDUCER_VERSION,
+    STATE_ACTIVE,
+    STATE_DEFERRED,
+    STATE_SUPPRESSED,
+    SurvivorReduction,
+    reduce_survivors,
+)
+
+
+_SAFETY_FLOOR = frozenset(
+    {
+        "Read",
+        "Edit",
+        "MultiEdit",
+        "Write",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Agent",
+        "Skill",
+        "TaskCreate",
+        "TaskUpdate",
+        "TaskList",
+    }
+)
+
+
+def _make_surface(
+    name: str,
+    *,
+    description: str = "",
+    capability_flags: int = 0,
+    state: str = STATE_ACTIVE,
+) -> dict[str, object]:
+    return {
+        "description": description,
+        "capability_flags": capability_flags,
+        "surface_state": state,
+    }
+
+
+def _make_synthetic_survivor_set(
+    n: int,
+    *,
+    extra: tuple[str, ...] = (),
+) -> tuple[frozenset[str], dict[str, dict[str, object]]]:
+    """Generate ``n`` synthetic MCP-style survivors plus optional extras."""
+    survivors: set[str] = set()
+    surface: dict[str, dict[str, object]] = {}
+    for idx in range(n):
+        nm = f"mcp__synth-server-{idx:03d}__do_thing"
+        survivors.add(nm)
+        surface[nm] = _make_surface(nm, description=f"synthetic tool {idx}")
+    for nm in extra:
+        survivors.add(nm)
+        if nm not in surface:
+            surface[nm] = _make_surface(nm)
+    return frozenset(survivors), surface
+
+
+# ── Test 1: modal 196-survivor case reduces to ≤20 with positive evidence ─────
+
+
+def test_modal_196_survivor_set_reduces_to_at_most_20_with_evidence() -> None:
+    survivors, surface = _make_synthetic_survivor_set(196)
+    # Add a Notion-family tool that should match the CRG capability "notion.search".
+    notion_tool = "mcp__notion-agents__notion-search"
+    survivors = frozenset(survivors | {notion_tool})
+    surface[notion_tool] = _make_surface(
+        notion_tool, description="search notion workspace"
+    )
+
+    reduction = reduce_survivors(
+        prompt="please search my notion workspace for the Q3 plan",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search", "notion.read"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+
+    assert reduction.original_count == 197
+    assert not reduction.abstained
+    # Shortlist capped at 20 evidence-positive tools.
+    evidence_positive = [
+        t for t in reduction.shortlisted_tools if t not in _SAFETY_FLOOR
+    ]
+    assert len(evidence_positive) <= 20
+    assert notion_tool in reduction.shortlisted_tools
+    # The Notion tool, with both lexical + CRG hits, must rank ahead of any
+    # synthetic tool with no evidence.
+    assert reduction.ranked_tools[0] == notion_tool
+
+
+# ── Test 2: 336-survivor case still capped at ≤20 plus safety floor ───────────
+
+
+def test_336_survivor_case_caps_at_20_plus_safety_floor() -> None:
+    survivors, surface = _make_synthetic_survivor_set(
+        336,
+        extra=tuple(_SAFETY_FLOOR),
+    )
+    # Add a tool with positive evidence so the reducer does not abstain.
+    notion_tool = "mcp__notion-agents__notion-search"
+    survivors = frozenset(survivors | {notion_tool})
+    surface[notion_tool] = _make_surface(notion_tool, description="search notion")
+
+    reduction = reduce_survivors(
+        prompt="check notion for the design doc",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+
+    assert not reduction.abstained
+    floor_in_shortlist = set(reduction.shortlisted_tools) & _SAFETY_FLOOR
+    non_floor_in_shortlist = [
+        t for t in reduction.shortlisted_tools if t not in _SAFETY_FLOOR
+    ]
+    # Every safety-floor tool that was a survivor must be preserved.
+    assert floor_in_shortlist == _SAFETY_FLOOR
+    # Non-floor entries are capped at the soft cap.
+    assert len(non_floor_in_shortlist) <= 20
+
+
+# ── Test 3: safety floor in survivors is always preserved ─────────────────────
+
+
+def test_safety_floor_survivors_always_preserved() -> None:
+    survivors, surface = _make_synthetic_survivor_set(
+        50,
+        extra=("Read", "Bash", "Edit"),
+    )
+    # Single positive-evidence tool unrelated to the safety floor.
+    notion_tool = "mcp__notion-agents__notion-search"
+    survivors = frozenset(survivors | {notion_tool})
+    surface[notion_tool] = _make_surface(notion_tool)
+
+    reduction = reduce_survivors(
+        prompt="search notion",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+
+    assert "Read" in reduction.shortlisted_tools
+    assert "Bash" in reduction.shortlisted_tools
+    assert "Edit" in reduction.shortlisted_tools
+    assert not reduction.abstained
+
+
+# ── Test 4: no positive evidence → abstain ────────────────────────────────────
+
+
+def test_no_positive_evidence_abstains() -> None:
+    survivors, surface = _make_synthetic_survivor_set(50)
+    reduction = reduce_survivors(
+        prompt="hello world",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=[],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert reduction.abstained
+    assert reduction.abstain_reason == ABSTAIN_NO_POSITIVE_EVIDENCE
+    assert reduction.shortlisted_tools == ()
+    assert reduction.shortlisted_count == 0
+    assert reduction.original_count == 50
+    # Ranking is still produced for telemetry, even when abstaining.
+    assert len(reduction.ranked_tools) == 50
+
+
+def test_empty_survivors_abstains_with_no_survivors_reason() -> None:
+    reduction = reduce_survivors(
+        prompt="any prompt",
+        survivor_names=frozenset(),
+        tool_surface_by_name={},
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=[],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert reduction.abstained
+    assert reduction.abstain_reason == ABSTAIN_NO_SURVIVORS
+    assert reduction.original_count == 0
+    assert reduction.shortlisted_tools == ()
+
+
+# ── Test 5: heuristic flags alone can rank but cannot hard-prune ──────────────
+
+
+def test_heuristic_flags_alone_cannot_drive_emit() -> None:
+    # Two survivors: one shares a heuristic flag bit, the other does not.
+    # No exact name, no CRG family, no lexical match.  Reducer must abstain.
+    survivors = frozenset({"mcp__alpha-server__some_action", "mcp__beta-server__other"})
+    surface = {
+        "mcp__alpha-server__some_action": _make_surface(
+            "mcp__alpha-server__some_action", capability_flags=0b1010
+        ),
+        "mcp__beta-server__other": _make_surface(
+            "mcp__beta-server__other", capability_flags=0b0001
+        ),
+    }
+    reduction = reduce_survivors(
+        prompt="generic request without any tool keywords",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0b1010,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0b1010,
+        crg_requested_capabilities=[],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert reduction.abstained, "heuristic flags alone must not yield emission"
+    assert reduction.abstain_reason == ABSTAIN_NO_POSITIVE_EVIDENCE
+    # But ranking still reflects the heuristic overlap.
+    assert reduction.ranked_tools[0] == "mcp__alpha-server__some_action"
+
+
+def test_heuristic_flags_can_break_ties_when_evidence_is_present() -> None:
+    notion_tool = "mcp__notion-agents__notion-search"
+    other_tool = "mcp__notion-agents__notion-write"
+    survivors = frozenset({notion_tool, other_tool})
+    surface = {
+        notion_tool: _make_surface(notion_tool, capability_flags=0b1110),
+        other_tool: _make_surface(other_tool, capability_flags=0b0001),
+    }
+    reduction = reduce_survivors(
+        prompt="use notion to search",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0b1110,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0b1110,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert not reduction.abstained
+    assert reduction.ranked_tools[0] == notion_tool
+
+
+# ── Test 6: CRG family match outranks unrelated tools ─────────────────────────
+
+
+def test_crg_family_match_ranks_above_unrelated() -> None:
+    notion_tool = "mcp__notion-agents__notion-search"
+    unrelated = "mcp__bay-view-graph__list_emails"
+    survivors = frozenset({notion_tool, unrelated})
+    surface = {
+        notion_tool: _make_surface(notion_tool),
+        unrelated: _make_surface(unrelated),
+    }
+    # Only the Notion CRG capability is requested.  A prompt that does not
+    # mention either tool name puts ranking entirely on CRG family + state.
+    reduction = reduce_survivors(
+        prompt="do something abstract",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert reduction.ranked_tools[0] == notion_tool
+    assert not reduction.abstained
+    assert notion_tool in reduction.shortlisted_tools
+
+
+# ── Determinism + structural invariants ───────────────────────────────────────
+
+
+def test_reducer_output_is_deterministic() -> None:
+    survivors, surface = _make_synthetic_survivor_set(80)
+    notion_tool = "mcp__notion-agents__notion-search"
+    survivors = frozenset(survivors | {notion_tool})
+    surface[notion_tool] = _make_surface(notion_tool)
+
+    args = dict(
+        prompt="search notion",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    a = reduce_survivors(**args)
+    b = reduce_survivors(**args)
+    assert a == b
+
+
+def test_reducer_version_string_is_stable() -> None:
+    assert REDUCER_VERSION == "imp23.evidence_gated_reducer.v1"
+
+
+def test_state_preference_active_outranks_deferred_when_other_signals_tie() -> None:
+    notion_active = "mcp__notion-agents__notion-search"
+    notion_deferred = "mcp__plugin_Notion_notion__notion-search"
+    survivors = frozenset({notion_active, notion_deferred})
+    surface = {
+        notion_active: _make_surface(notion_active, state=STATE_ACTIVE),
+        notion_deferred: _make_surface(notion_deferred, state=STATE_DEFERRED),
+    }
+    reduction = reduce_survivors(
+        prompt="notion search",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert reduction.ranked_tools[0] == notion_active
+
+
+# ── Replay-style fixture against decisions.jsonl when present ─────────────────
+
+
+@pytest.mark.skipif(
+    not (Path.home() / ".tcp-shadow" / "proxy" / "decisions.jsonl").exists(),
+    reason="local decisions.jsonl not present in CI",
+)
+def test_replay_against_local_corpus_caps_broad_survivors() -> None:
+    """When real corpus is available, broad-survivor rows with positive evidence
+    must shortlist to ≤20 (plus safety-floor entries).
+
+    This test is opportunistic: it is skipped in CI and on machines without a
+    locally-running proxy.  It is meaningful on the operator's workstation.
+    """
+    path = Path.home() / ".tcp-shadow" / "proxy" / "decisions.jsonl"
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("expected_tool_derivation_algorithm") != "imp22.evidence_gated.v1":
+                continue
+            sc = rec.get("survivor_count")
+            if not isinstance(sc, int) or sc < 50:
+                continue
+            rows.append(rec)
+    if not rows:
+        pytest.skip("no broad-survivor post-IMP-22 rows in local corpus")
+
+    # We do not have the original prompt text in decisions.jsonl (only its
+    # excerpt) nor the full tool surface, so this fixture only verifies the
+    # reducer's invariants on synthetic survivor sets sized to match the
+    # observed buckets.  It is a structural sanity check, not a precision test.
+    distinct_buckets = sorted({rec["survivor_count"] for rec in rows})[:5]
+    for size in distinct_buckets:
+        assert isinstance(size, int)
+        survivors, surface = _make_synthetic_survivor_set(size)
+        notion = "mcp__notion-agents__notion-search"
+        survivors = frozenset(survivors | {notion})
+        surface[notion] = _make_surface(notion)
+        reduction = reduce_survivors(
+            prompt="search notion",
+            survivor_names=survivors,
+            tool_surface_by_name=surface,
+            required_capability_flags=0,
+            hard_capability_flags=0,
+            heuristic_capability_flags=0,
+            crg_requested_capabilities=["notion.search"],
+            safety_floor_tools=_SAFETY_FLOOR,
+        )
+        non_floor = [t for t in reduction.shortlisted_tools if t not in _SAFETY_FLOOR]
+        assert len(non_floor) <= 20, (
+            f"reducer exceeded shortlist cap on survivor_count={size}: "
+            f"non_floor_count={len(non_floor)}"
+        )
+
+
+# ── Integration with cc_proxy: telemetry surfaces in decisions meta ──────────
+
+
+def test_proxy_meta_emits_reducer_telemetry_in_shadow_mode() -> None:
+    from tcp.proxy.cc_proxy import _process_tools_array  # local import
+
+    tools = [
+        {"name": "Read", "description": "read", "input_schema": {"type": "object"}},
+        {"name": "Bash", "description": "shell", "input_schema": {"type": "object"}},
+        {
+            "name": "mcp__notion-agents__notion-search",
+            "description": "search notion",
+            "input_schema": {"type": "object"},
+        },
+    ]
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "search my notion workspace"}],
+            }
+        ],
+    }
+    _, meta = _process_tools_array(tools, body, "shadow")
+    assert meta is not None
+    assert meta.get("reducer_version") == REDUCER_VERSION
+    assert isinstance(meta.get("reducer_original_count"), int)
+    assert isinstance(meta.get("reducer_shortlisted_count"), int)
+    assert isinstance(meta.get("reducer_shortlisted_tools"), list)
+    assert isinstance(meta.get("reducer_ranked_tools"), list)
+    assert isinstance(meta.get("reducer_abstained"), bool)
+    assert "reducer_feature_summary" in meta
+    # In shadow mode, the live tools list must be unchanged.
+    assert meta["tool_count_after"] == len(tools)
+
+
+def test_proxy_meta_reducer_does_not_alter_live_tools() -> None:
+    from tcp.proxy.cc_proxy import _process_tools_array
+
+    tools = [
+        {"name": "Read", "description": "read", "input_schema": {"type": "object"}},
+        {
+            "name": "mcp__notion-agents__notion-search",
+            "description": "search notion",
+            "input_schema": {"type": "object"},
+        },
+    ]
+    body = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "search notion"}]}
+        ],
+    }
+    out_tools, meta = _process_tools_array(tools, body, "shadow")
+    assert meta is not None
+    assert len(out_tools) == len(tools)
+    # Reducer telemetry is present, but the tools list is unchanged.
+    assert meta.get("reducer_version") == REDUCER_VERSION
+
+
+def test_dataclass_invariants() -> None:
+    sr = SurvivorReduction(
+        original_count=0,
+        shortlisted_count=0,
+        shortlisted_tools=(),
+        ranked_tools=(),
+        abstained=True,
+        abstain_reason=ABSTAIN_NO_SURVIVORS,
+        reducer_version=REDUCER_VERSION,
+    )
+    # SurvivorReduction is frozen — mutation must raise.
+    with pytest.raises(Exception):
+        sr.shortlisted_count = 5  # type: ignore[misc]

--- a/tests/unit/test_survivor_reducer.py
+++ b/tests/unit/test_survivor_reducer.py
@@ -18,7 +18,6 @@ from tcp.proxy.survivor_reducer import (
     reduce_survivors,
 )
 
-
 _SAFETY_FLOOR = frozenset(
     {
         "Read",
@@ -212,6 +211,37 @@ def test_empty_survivors_abstains_with_no_survivors_reason() -> None:
     assert reduction.shortlisted_tools == ()
 
 
+def test_feature_summary_schema_is_stable_across_paths() -> None:
+    """Empty-survivors path emits the same keys as the populated path."""
+    populated = reduce_survivors(
+        prompt="search notion",
+        survivor_names=frozenset({"mcp__notion-agents__notion-search"}),
+        tool_surface_by_name={
+            "mcp__notion-agents__notion-search": _make_surface(
+                "mcp__notion-agents__notion-search"
+            )
+        },
+        required_capability_flags=1,
+        hard_capability_flags=2,
+        heuristic_capability_flags=4,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+        max_shortlist=20,
+    )
+    empty = reduce_survivors(
+        prompt="anything",
+        survivor_names=frozenset(),
+        tool_surface_by_name={},
+        required_capability_flags=1,
+        hard_capability_flags=2,
+        heuristic_capability_flags=4,
+        crg_requested_capabilities=["notion.search"],
+        safety_floor_tools=_SAFETY_FLOOR,
+        max_shortlist=20,
+    )
+    assert set(populated.feature_summary.keys()) == set(empty.feature_summary.keys())
+
+
 # ── Test 5: heuristic flags alone can rank but cannot hard-prune ──────────────
 
 
@@ -263,6 +293,48 @@ def test_heuristic_flags_can_break_ties_when_evidence_is_present() -> None:
     )
     assert not reduction.abstained
     assert reduction.ranked_tools[0] == notion_tool
+
+
+# ── Token-boundary precision: substrings must not register as evidence ───────
+
+
+def test_exact_name_requires_word_boundary_not_substring() -> None:
+    """``git`` server name must not match inside ``digital`` (Codex review)."""
+    git_tool = "mcp__git__git_status"
+    survivors = frozenset({git_tool})
+    surface = {git_tool: _make_surface(git_tool)}
+    reduction = reduce_survivors(
+        prompt="explain digital signatures",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=[],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert (
+        reduction.abstained
+    ), "substring of 'git' inside 'digital' must not register as evidence"
+    assert reduction.abstain_reason == ABSTAIN_NO_POSITIVE_EVIDENCE
+
+
+def test_exact_name_fires_on_word_bounded_mention() -> None:
+    git_tool = "mcp__git__git_status"
+    survivors = frozenset({git_tool})
+    surface = {git_tool: _make_surface(git_tool)}
+    reduction = reduce_survivors(
+        prompt="run git status please",
+        survivor_names=survivors,
+        tool_surface_by_name=surface,
+        required_capability_flags=0,
+        hard_capability_flags=0,
+        heuristic_capability_flags=0,
+        crg_requested_capabilities=[],
+        safety_floor_tools=_SAFETY_FLOOR,
+    )
+    assert not reduction.abstained
+    assert git_tool in reduction.shortlisted_tools
 
 
 # ── Test 6: CRG family match outranks unrelated tools ─────────────────────────
@@ -364,7 +436,10 @@ def test_replay_against_local_corpus_caps_broad_survivors() -> None:
                 rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if rec.get("expected_tool_derivation_algorithm") != "imp22.evidence_gated.v1":
+            if (
+                rec.get("expected_tool_derivation_algorithm")
+                != "imp22.evidence_gated.v1"
+            ):
                 continue
             sc = rec.get("survivor_count")
             if not isinstance(sc, int) or sc < 50:


### PR DESCRIPTION
## Summary

Adds a **Stage 4.5 evidence-gated survivor reducer** to the TCP-CC proxy that ranks `active_survivors` with transparent feature scoring and produces a capped shortlist for telemetry. **Shadow-only**: `live_tools` is not modified by this PR.

## Why now

Post-IMP-22 analysis on 651 rows of real traffic shows `survivor_count` never reaches 1; the modal operating point is **196 survivors** and the maximum is **336**. IMP-22 correctly abstains from emitting `expected_tool_name` in that regime, but the proxy had no bounded reduction stage to record *which* of those survivors are most plausibly relevant to the request. This PR adds that record so future work can calibrate against it without changing live behavior.

## What changed

**New module — `tcp/proxy/survivor_reducer.py`**
- `SurvivorReduction` frozen dataclass (`original_count`, `shortlisted_count`, `shortlisted_tools`, `ranked_tools`, `abstained`, `abstain_reason`, `reducer_version`, `feature_summary`)
- `reduce_survivors()` pure function with five transparent feature signals:
  1. exact tool/server name mention in prompt
  2. CRG capability family match
  3. heuristic capability-flag overlap (ranks but cannot hard-prune)
  4. command/name lexical match
  5. pack state preference (ACTIVE > DEFERRED > SUPPRESSED)
- `REDUCER_VERSION = "imp23.evidence_gated_reducer.v1"`

**Wiring — `tcp/proxy/cc_proxy.py`**
- Reducer invoked after CRG resolution and before the empty-set guardrail.
- `live_tools` is **not** mutated — the new fields land in `meta` only.
- IMP-22 `expected_tool_name` and CRG denial enforcement are unchanged.

**New telemetry fields in `decisions.jsonl`**
- `reducer_version`, `reducer_original_count`, `reducer_shortlisted_count`, `reducer_shortlisted_tools`, `reducer_ranked_tools`, `reducer_abstained`, `reducer_abstain_reason`, `reducer_feature_summary`

## Invariants preserved

- Safety floor (`_SAFETY_FLOOR_TOOLS`) members in survivors are always in the shortlist; `safety_floor_drop_count = 0` by construction.
- Heuristic capability flags never alone trigger emission.
- No positive evidence → abstain (`reducer_abstained = true`, `abstain_reason = "no_positive_evidence"`); shortlist is empty but the survivor set is preserved in the existing `survivor_names_sorted` field.
- Empty survivors → abstain with `"no_survivors"`.

## Test plan

- [x] 15 new unit tests in `tests/unit/test_survivor_reducer.py` — all pass
- [x] Modal 196-survivor synthetic case → shortlist ≤20 with positive evidence
- [x] 336-survivor synthetic case → shortlist ≤20 (non-floor) plus full safety floor
- [x] Safety-floor preservation
- [x] No positive evidence → abstain
- [x] Heuristic flags alone cannot drive emit
- [x] CRG family ranks above unrelated tools
- [x] Determinism (same inputs → same output)
- [x] Proxy integration: reducer fields appear in shadow-mode meta
- [x] Local-corpus replay fixture (opportunistic, skipped in CI)
- [x] Existing IMP-22 expected_tool_name tests pass (no regressions)
- [x] Existing CRG and denial-enforcement tests pass
- [x] Existing response-tap tests pass

Full local run on the 397-test core unit suite: **397 passed, 1 skipped, 0 failed**.

## Out of scope (deliberately)

- This PR does **not** change `live_tools` sent upstream.
- This PR does **not** override IMP-22 `expected_tool_name` derivation.
- Prompt-similarity is not reintroduced as ground truth.
- `first_tool_name` is not used as task-correctness ground truth.

## Note on Work Item numbering

The prior commit `cb6f6df` ("decision_log_schema and derivation algorithm version fields") was also tagged `TCP-IMP-23` on `main`. This PR reuses the handle as instructed by the dispatch spec. If the Lab Work Item should be re-numbered (e.g., `TCP-IMP-24`), the rename is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)