### PR TITLE
style: satisfy quality formatting gates

### DIFF
--- a/scripts/bootstrap_exp3.py
+++ b/scripts/bootstrap_exp3.py
@@ -22,6 +22,7 @@ SEED = 42
 
 # ── data loading ─────────────────────────────────────────────────────────────
 
+
 def load_exp3():
     path = REPO / "exp3-results.json"
     with open(path) as f:
@@ -29,6 +30,7 @@ def load_exp3():
 
 
 # ── bootstrap helpers ─────────────────────────────────────────────────────────
+
 
 def bootstrap_ci(
     data: list,
@@ -85,9 +87,11 @@ def mean_fn(xs: list) -> float:
 
 # ── minimum detectable effect (MDE) ──────────────────────────────────────────
 
+
 def power_two_proportions(n: int, p1: float, p2: float, alpha: float = 0.05) -> float:
     """Approximate power for two-proportion z-test (two-tailed)."""
     import math
+
     z_alpha = 1.96
     p_bar = (p1 + p2) / 2
     se_alt = math.sqrt(p1 * (1 - p1) / n + p2 * (1 - p2) / n)
@@ -97,7 +101,9 @@ def power_two_proportions(n: int, p1: float, p2: float, alpha: float = 0.05) -> 
     return 1 - _norm_cdf(z_alpha - ncp) + _norm_cdf(-z_alpha - ncp)
 
 
-def n_required_two_proportions(p1: float, p2: float, power: float = 0.80, alpha: float = 0.05) -> int:
+def n_required_two_proportions(
+    p1: float, p2: float, power: float = 0.80, alpha: float = 0.05
+) -> int:
     """Return n per arm needed to detect |p2-p1| at given power."""
     for n in range(5, 10_000):
         if power_two_proportions(n, p1, p2, alpha) >= power:
@@ -105,7 +111,9 @@ def n_required_two_proportions(p1: float, p2: float, power: float = 0.80, alpha:
     return 10_000
 
 
-def mde_two_proportions(n: int, p1: float = 0.83, power: float = 0.80, alpha: float = 0.05) -> float:
+def mde_two_proportions(
+    n: int, p1: float = 0.83, power: float = 0.80, alpha: float = 0.05
+) -> float:
     """
     MDE for two-proportion z-test at given n per arm.
     Returns smallest detectable delta (p2 - p1) at given power.
@@ -123,10 +131,12 @@ def mde_two_proportions(n: int, p1: float = 0.83, power: float = 0.80, alpha: fl
 
 def _norm_cdf(x: float) -> float:
     import math
+
     return 0.5 * (1 + math.erf(x / math.sqrt(2)))
 
 
 # ── main ──────────────────────────────────────────────────────────────────────
+
 
 def main():
     trials = load_exp3()
@@ -141,13 +151,15 @@ def main():
 
     # extract per-arm series
     correct = {arm: [t[arm]["selected_tool_correct"] for t in trials] for arm in arms}
-    tokens  = {arm: [t[arm]["input_tokens"] for t in trials] for arm in arms}
+    tokens = {arm: [t[arm]["input_tokens"] for t in trials] for arm in arms}
 
     rng = random.Random(SEED)
 
     print("=" * 72)
     print("TCP-MT-9  Bootstrap CIs — EXP-3 4-Arm Ablation")
-    print(f"n = {n} tasks per arm  |  bootstrap iterations = {N_BOOT:,}  |  seed = {SEED}")
+    print(
+        f"n = {n} tasks per arm  |  bootstrap iterations = {N_BOOT:,}  |  seed = {SEED}"
+    )
     print("=" * 72)
 
     # ── Table 1: correctness CIs ─────────────────────────────────────────────
@@ -159,7 +171,9 @@ def main():
         obs, lo, hi = bootstrap_ci(correct[arm], mean_fn, rng=rng)
         corr_ci[arm] = (obs, lo, hi)
         n_ok = sum(correct[arm])
-        print(f"{arm_labels[arm]:<42}  {obs:>6.1%}  {lo:>6.1%}  {hi:>6.1%}  {n_ok:>5}/{n}")
+        print(
+            f"{arm_labels[arm]:<42}  {obs:>6.1%}  {lo:>6.1%}  {hi:>6.1%}  {n_ok:>5}/{n}"
+        )
 
     # ── Table 2: token CIs ───────────────────────────────────────────────────
     print("\n── Table 2: Per-Arm Mean Input Tokens (95% CI) ────────────────────\n")
@@ -171,27 +185,37 @@ def main():
 
     # ── Table 3: pairwise correctness differences ────────────────────────────
     print("\n── Table 3: Pairwise Correctness Differences (A as reference) ──────\n")
-    print(f"{'Comparison':<26}  {'Δ correct':>9}  {'95% CI':>20}  {'p-value':>8}  {'sig?':>6}")
+    print(
+        f"{'Comparison':<26}  {'Δ correct':>9}  {'95% CI':>20}  {'p-value':>8}  {'sig?':>6}"
+    )
     print("-" * 72)
     ref = "arm_a"
     for arm in arms[1:]:
         obs_a, lo_a, hi_a = corr_ci[ref]
         obs_b, lo_b, hi_b = corr_ci[arm]
-        diff_obs, p = bootstrap_diff_pvalue(correct[ref], correct[arm], mean_fn, rng=rng)
+        diff_obs, p = bootstrap_diff_pvalue(
+            correct[ref], correct[arm], mean_fn, rng=rng
+        )
         # CI on the difference via paired bootstrap
         diffs = [c - a for c, a in zip(correct[arm], correct[ref])]
         _, diff_lo, diff_hi = bootstrap_ci(diffs, mean_fn, rng=rng)
         sig = "✓" if p < 0.05 else "✗"
         label = f"A vs {arm.split('_')[1].upper()}"
-        print(f"{label:<26}  {diff_obs:>+8.1%}  [{diff_lo:>+7.1%}, {diff_hi:>+7.1%}]  {p:>8.4f}  {sig:>6}")
+        print(
+            f"{label:<26}  {diff_obs:>+8.1%}  [{diff_lo:>+7.1%}, {diff_hi:>+7.1%}]  {p:>8.4f}  {sig:>6}"
+        )
 
     # ── Table 4: all pairs for completeness ─────────────────────────────────
     print("\n── Table 4: C vs D (minimal vs brief) ─────────────────────────────\n")
-    diff_obs, p = bootstrap_diff_pvalue(correct["arm_c"], correct["arm_d"], mean_fn, rng=rng)
+    diff_obs, p = bootstrap_diff_pvalue(
+        correct["arm_c"], correct["arm_d"], mean_fn, rng=rng
+    )
     diffs = [d - c for d, c in zip(correct["arm_d"], correct["arm_c"])]
     _, diff_lo, diff_hi = bootstrap_ci(diffs, mean_fn, rng=rng)
     sig = "✓" if p < 0.05 else "✗"
-    print(f"{'C vs D':<26}  {diff_obs:>+8.1%}  [{diff_lo:>+7.1%}, {diff_hi:>+7.1%}]  {p:>8.4f}  {sig:>6}")
+    print(
+        f"{'C vs D':<26}  {diff_obs:>+8.1%}  [{diff_lo:>+7.1%}, {diff_hi:>+7.1%}]  {p:>8.4f}  {sig:>6}"
+    )
 
     # ── MDE / power analysis ─────────────────────────────────────────────────
     p1_baseline = corr_ci["arm_a"][0]
@@ -204,7 +228,9 @@ def main():
 
     print(f"\n── Power Analysis ──────────────────────────────────────────────────\n")
     print(f"  n per arm (actual):       {n}")
-    print(f"  MDE at n=36, 80% power:   {'±'+f'{mde:.0%}' if not (mde!=mde) else 'unachievable at this n (ceiling effect)'}")
+    print(
+        f"  MDE at n=36, 80% power:   {'±'+f'{mde:.0%}' if not (mde!=mde) else 'unachievable at this n (ceiling effect)'}"
+    )
     print(f"  Observed A→C diff:        +{obs_diff_ac:.1%}")
     print(f"  Power at observed delta:  {pow_at_n:.1%}")
     print(f"  n needed to detect +{obs_diff_ac:.1%} at 80% power:  {n_needed} per arm")
@@ -219,17 +245,27 @@ def main():
     print(f"  Savings:            {savings_pct:.0%}")
 
     # ── Verdict ──────────────────────────────────────────────────────────────
-    _, p_ac = bootstrap_diff_pvalue(correct["arm_a"], correct["arm_c"], mean_fn, rng=rng)
+    _, p_ac = bootstrap_diff_pvalue(
+        correct["arm_a"], correct["arm_c"], mean_fn, rng=rng
+    )
     print("\n" + "=" * 72)
     print("VERDICT")
     print("=" * 72)
     if p_ac < 0.05 and obs_diff_ac > 0:
-        print(f"  PASS — A vs C difference is statistically significant (p={p_ac:.4f}).")
-        print(f"  Minimal TCP descriptions outperform behavioral prose by +{obs_diff_ac:.0%}pp")
-        print(f"  correctness while saving {savings_pct:.0%} tokens. Effect exceeds MDE.")
+        print(
+            f"  PASS — A vs C difference is statistically significant (p={p_ac:.4f})."
+        )
+        print(
+            f"  Minimal TCP descriptions outperform behavioral prose by +{obs_diff_ac:.0%}pp"
+        )
+        print(
+            f"  correctness while saving {savings_pct:.0%} tokens. Effect exceeds MDE."
+        )
     elif p_ac < 0.10:
         print(f"  MARGINAL — p={p_ac:.4f} (trend, not significant at α=0.05).")
-        print(f"  Directional signal for A→C but sample is underpowered for this delta.")
+        print(
+            f"  Directional signal for A→C but sample is underpowered for this delta."
+        )
     else:
         print(f"  FAIL — A vs C difference not significant (p={p_ac:.4f}).")
         print(f"  Cannot reject H0 at this sample size. Findings are directional only.")

--- a/scripts/build_tcp_data_1_audit_set.py
+++ b/scripts/build_tcp_data_1_audit_set.py
@@ -65,9 +65,18 @@ class LabelTurn:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build the TCP-DATA-1 labeling package")
-    parser.add_argument("--limit", type=int, default=50, help="Number of labeled turns to prepare")
-    parser.add_argument("--calibration-size", type=int, default=10, help="Double-label calibration slice size")
+    parser = argparse.ArgumentParser(
+        description="Build the TCP-DATA-1 labeling package"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Number of labeled turns to prepare"
+    )
+    parser.add_argument(
+        "--calibration-size",
+        type=int,
+        default=10,
+        help="Double-label calibration slice size",
+    )
     parser.add_argument("--seed", type=int, default=42, help="Sampling seed")
     parser.add_argument(
         "--package-dir",
@@ -79,7 +88,9 @@ def main() -> None:
 
     turns = collect_turns()
     if len(turns) < args.limit:
-        raise SystemExit(f"Only {len(turns)} eligible turns found; need at least {args.limit}.")
+        raise SystemExit(
+            f"Only {len(turns)} eligible turns found; need at least {args.limit}."
+        )
 
     ranked = sorted(turns, key=turn_score, reverse=True)
     selected = pick_diverse_turns(ranked, args.limit, args.seed)
@@ -88,9 +99,18 @@ def main() -> None:
     args.package_dir.mkdir(parents=True, exist_ok=True)
     write_jsonl(args.package_dir / "candidate_turns.jsonl", selected)
     write_jsonl(args.package_dir / "calibration_slice.jsonl", calibration)
-    write_text(args.package_dir / "protocol.md", render_protocol(args.limit, args.calibration_size))
-    write_text(args.package_dir / "adjudication_log.md", render_adjudication_template(calibration))
-    write_text(args.package_dir / "provenance_and_limitations.md", render_provenance(turns, selected))
+    write_text(
+        args.package_dir / "protocol.md",
+        render_protocol(args.limit, args.calibration_size),
+    )
+    write_text(
+        args.package_dir / "adjudication_log.md",
+        render_adjudication_template(calibration),
+    )
+    write_text(
+        args.package_dir / "provenance_and_limitations.md",
+        render_provenance(turns, selected),
+    )
     write_text(args.package_dir / "README.md", render_readme())
 
     print(f"Prepared TCP-DATA-1 package in {args.package_dir}")
@@ -102,8 +122,14 @@ def main() -> None:
 def collect_turns() -> list[LabelTurn]:
     turns: list[LabelTurn] = []
     for session_path in sorted(SESSIONS_DIR.glob("*.jsonl")):
-        records = [json.loads(line) for line in session_path.read_text().splitlines() if line.strip()]
-        session_start = next((r for r in records if r.get("event") == "session_start"), None)
+        records = [
+            json.loads(line)
+            for line in session_path.read_text().splitlines()
+            if line.strip()
+        ]
+        session_start = next(
+            (r for r in records if r.get("event") == "session_start"), None
+        )
         if not session_start:
             continue
 
@@ -132,9 +158,19 @@ def collect_turns() -> list[LabelTurn]:
                 continue
 
             derived = derive_request(prompt, session)
-            observed_tool_names = sorted({tool["tool_name"] for tool in tool_uses if tool.get("tool_result_status") == "ok"})
+            observed_tool_names = sorted(
+                {
+                    tool["tool_name"]
+                    for tool in tool_uses
+                    if tool.get("tool_result_status") == "ok"
+                }
+            )
             observed_equivalence_classes = sorted(
-                {get_equivalence_class(tool["tool_name"], {}) for tool in tool_uses if tool.get("tool_result_status") == "ok"}
+                {
+                    get_equivalence_class(tool["tool_name"], {})
+                    for tool in tool_uses
+                    if tool.get("tool_result_status") == "ok"
+                }
             )
 
             turns.append(
@@ -146,11 +182,17 @@ def collect_turns() -> list[LabelTurn]:
                     permission_mode=session.permission_mode,
                     observed_tool_names=observed_tool_names,
                     observed_equivalence_classes=observed_equivalence_classes,
-                    ok_tool_count=sum(1 for tool in tool_uses if tool.get("tool_result_status") == "ok"),
+                    ok_tool_count=sum(
+                        1
+                        for tool in tool_uses
+                        if tool.get("tool_result_status") == "ok"
+                    ),
                     coverage_audit_suitable=len(observed_equivalence_classes) == 1,
                     proxy_required_capability_flags=derived.required_capability_flags,
                     proxy_heuristic_capability_flags=derived.heuristic_capability_flags,
-                    proxy_required_output_formats=sorted(derived.required_output_formats),
+                    proxy_required_output_formats=sorted(
+                        derived.required_output_formats
+                    ),
                     label_status="unlabeled",
                     rater1_flags=None,
                     rater1_formats=None,
@@ -174,7 +216,9 @@ def is_labelable_turn(prompt: str, tool_uses: list[dict]) -> bool:
     if len(tokens) < 5 and not has_url:
         return False
 
-    ok_tool_uses = [tool for tool in tool_uses if tool.get("tool_result_status") == "ok"]
+    ok_tool_uses = [
+        tool for tool in tool_uses if tool.get("tool_result_status") == "ok"
+    ]
     if not ok_tool_uses:
         return False
 
@@ -209,7 +253,9 @@ def turn_score(turn: LabelTurn) -> tuple[int, int, int, int]:
     )
 
 
-def pick_diverse_turns(turns: list[LabelTurn], limit: int, seed: int) -> list[LabelTurn]:
+def pick_diverse_turns(
+    turns: list[LabelTurn], limit: int, seed: int
+) -> list[LabelTurn]:
     rng = random.Random(seed)
     by_class: dict[str, list[LabelTurn]] = {}
     for turn in turns:
@@ -322,9 +368,7 @@ def render_adjudication_template(calibration: list[LabelTurn]) -> str:
 
 def render_provenance(all_turns: list[LabelTurn], selected: list[LabelTurn]) -> str:
     by_class = Counter(
-        cls
-        for turn in selected
-        for cls in turn.observed_equivalence_classes
+        cls for turn in selected for cls in turn.observed_equivalence_classes
     )
     suitable = sum(1 for turn in selected if turn.coverage_audit_suitable)
     return f"""# TCP-DATA-1 Provenance and Limitations

--- a/scripts/generate_audit_set.py
+++ b/scripts/generate_audit_set.py
@@ -35,13 +35,17 @@ SMOKE_CASES = [
     {
         "session_id": "synthetic_network_1",
         "prompt": "Fetch https://example.com/api/status and return the response body as plain text for inspection.",
-        "ground_truth_flags": int(CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK),
+        "ground_truth_flags": int(
+            CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK
+        ),
         "ground_truth_formats": ["text"],
     },
     {
         "session_id": "synthetic_network_2",
         "prompt": "Download the JSON payload from https://example.com/api/report and return it as structured json.",
-        "ground_truth_flags": int(CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK),
+        "ground_truth_flags": int(
+            CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK
+        ),
         "ground_truth_formats": ["text", "json"],
     },
     {
@@ -53,13 +57,17 @@ SMOKE_CASES = [
     {
         "session_id": "synthetic_files_auth_1",
         "prompt": "Use sudo to open the local secrets.yaml file, inspect the active settings, and answer in plain text.",
-        "ground_truth_flags": int(CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.AUTH_REQUIRED),
+        "ground_truth_flags": int(
+            CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.AUTH_REQUIRED
+        ),
         "ground_truth_formats": ["text"],
     },
     {
         "session_id": "synthetic_files_network_1",
         "prompt": "Compare the local config.yaml file against the remote response at https://example.com/api/config and summarize the differences in text.",
-        "ground_truth_flags": int(CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK),
+        "ground_truth_flags": int(
+            CapabilityFlags.SUPPORTS_FILES | CapabilityFlags.SUPPORTS_NETWORK
+        ),
         "ground_truth_formats": ["text"],
     },
     {

--- a/scripts/mt16_measure.py
+++ b/scripts/mt16_measure.py
@@ -62,11 +62,18 @@ def quartile_label(val: float | None, quartiles: list[float]) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--since", default=RESTART_TS,
-                        help="ISO8601 timestamp — only records after this are analysed")
+    parser.add_argument(
+        "--since",
+        default=RESTART_TS,
+        help="ISO8601 timestamp — only records after this are analysed",
+    )
     parser.add_argument("--log", default=str(DECISIONS_LOG))
-    parser.add_argument("--min-hours", type=float, default=4.0,
-                        help="Minimum window in hours before full report (kill gate)")
+    parser.add_argument(
+        "--min-hours",
+        type=float,
+        default=4.0,
+        help="Minimum window in hours before full report (kill gate)",
+    )
     args = parser.parse_args()
 
     log = Path(args.log)
@@ -94,20 +101,26 @@ def main() -> None:
     # ── Population rate (kill gate) ────────────────────────────────────────────
     has_expected = [r for r in records if r.get("expected_tool_name") is not None]
     population_rate = len(has_expected) / total * 100
-    print(f"\n[KILL GATE] expected_tool_name population rate: "
-          f"{len(has_expected)}/{total} = {population_rate:.1f}%")
+    print(
+        f"\n[KILL GATE] expected_tool_name population rate: "
+        f"{len(has_expected)}/{total} = {population_rate:.1f}%"
+    )
     if population_rate < 5.0:
         print("  ⛔ KILL CONDITION FIRES — rate < 5%. IMP-16 threshold too tight.")
         print("     Recommendation: survivor_count ≤ k approach insufficient;")
         print("     consider task-match ranking as next approach.")
         if window_hours < args.min_hours:
-            print(f"  ⚠ Window only {window_hours:.2f}h — wait for {args.min_hours}h before concluding.")
+            print(
+                f"  ⚠ Window only {window_hours:.2f}h — wait for {args.min_hours}h before concluding."
+            )
         sys.exit(2)
     else:
         print(f"  ✅ Population rate above 5% threshold — measurement viable.")
 
     if window_hours < args.min_hours:
-        print(f"\n⚠ Window only {window_hours:.2f}h — {args.min_hours - window_hours:.1f}h remaining.")
+        print(
+            f"\n⚠ Window only {window_hours:.2f}h — {args.min_hours - window_hours:.1f}h remaining."
+        )
         print("  Partial results follow (not final):\n")
 
     # ── Ambiguous-lane miss rate ────────────────────────────────────────────────
@@ -115,8 +128,10 @@ def main() -> None:
     correct = [r for r in evaluable if r.get("first_tool_correct") is True]
     misses = [r for r in evaluable if r.get("first_tool_correct") is False]
     miss_rate = len(misses) / len(evaluable) * 100 if evaluable else float("nan")
-    print(f"\nAmbiguous-lane miss rate (evaluable turns): "
-          f"{len(misses)}/{len(evaluable)} = {miss_rate:.1f}%")
+    print(
+        f"\nAmbiguous-lane miss rate (evaluable turns): "
+        f"{len(misses)}/{len(evaluable)} = {miss_rate:.1f}%"
+    )
 
     # ── Mean retry latency penalty ─────────────────────────────────────────────
     # Proxy records req_ts; latency proxy: turns where first_tool_correct=False
@@ -137,24 +152,35 @@ def main() -> None:
     if miss_latencies and hit_latencies:
         mean_miss = statistics.mean(miss_latencies)
         mean_hit = statistics.mean(hit_latencies)
-        print(f"\nMean latency — hits: {mean_hit:.0f}ms  misses: {mean_miss:.0f}ms  "
-              f"penalty: {mean_miss - mean_hit:+.0f}ms")
+        print(
+            f"\nMean latency — hits: {mean_hit:.0f}ms  misses: {mean_miss:.0f}ms  "
+            f"penalty: {mean_miss - mean_hit:+.0f}ms"
+        )
     else:
         print("\nMean retry latency penalty: insufficient latency data in records")
 
     # ── Miss rate by similarity quartile ──────────────────────────────────────
-    sim_vals = [r.get("description_similarity_max") for r in evaluable
-                if r.get("description_similarity_max") is not None]
+    sim_vals = [
+        r.get("description_similarity_max")
+        for r in evaluable
+        if r.get("description_similarity_max") is not None
+    ]
     if sim_vals and len(sim_vals) >= 4:
         q1, q2, q3 = (
             statistics.quantiles(sim_vals, n=4)[0],
             statistics.quantiles(sim_vals, n=4)[1],
             statistics.quantiles(sim_vals, n=4)[2],
         )
-        print(f"\nMiss rate by similarity quartile (Q1≤{q1:.2f} Q2≤{q2:.2f} Q3≤{q3:.2f}):")
+        print(
+            f"\nMiss rate by similarity quartile (Q1≤{q1:.2f} Q2≤{q2:.2f} Q3≤{q3:.2f}):"
+        )
         for qlabel in ("Q1", "Q2", "Q3", "Q4"):
-            q_eval = [r for r in evaluable
-                      if quartile_label(r.get("description_similarity_max"), [q1, q2, q3]) == qlabel]
+            q_eval = [
+                r
+                for r in evaluable
+                if quartile_label(r.get("description_similarity_max"), [q1, q2, q3])
+                == qlabel
+            ]
             q_miss = [r for r in q_eval if r.get("first_tool_correct") is False]
             rate = len(q_miss) / len(q_eval) * 100 if q_eval else float("nan")
             print(f"  {qlabel}: {len(q_miss)}/{len(q_eval)} = {rate:.1f}%")
@@ -162,26 +188,38 @@ def main() -> None:
         print("\nMiss rate by similarity quartile: insufficient similarity data")
 
     # ── Pack-promotion miss rate ───────────────────────────────────────────────
-    promoted = [r for r in evaluable if r.get("pack_promoted") or
-                r.get("derivation_method") == "pack_promotion"]
+    promoted = [
+        r
+        for r in evaluable
+        if r.get("pack_promoted") or r.get("derivation_method") == "pack_promotion"
+    ]
     promo_miss = [r for r in promoted if r.get("first_tool_correct") is False]
-    promo_miss_rate = len(promo_miss) / len(promoted) * 100 if promoted else float("nan")
-    print(f"\nPack-promotion miss rate: {len(promo_miss)}/{len(promoted)} = {promo_miss_rate:.1f}%"
-          if promoted else "\nPack-promotion miss rate: no promoted turns in window")
+    promo_miss_rate = (
+        len(promo_miss) / len(promoted) * 100 if promoted else float("nan")
+    )
+    print(
+        f"\nPack-promotion miss rate: {len(promo_miss)}/{len(promoted)} = {promo_miss_rate:.1f}%"
+        if promoted
+        else "\nPack-promotion miss rate: no promoted turns in window"
+    )
 
     # ── MT-12 reopen gate ──────────────────────────────────────────────────────
     print("\n── MT-12 reopen gate assessment ──")
     print(f"  Population rate:   {population_rate:.1f}%  (gate fires if <5%)")
     print(f"  Ambiguous miss:    {miss_rate:.1f}%")
     if miss_rate > 50:
-        print("  ⚠ Miss rate >50% — MT-12 hypothesis under stress; consider IMP-9 (conservative mode).")
+        print(
+            "  ⚠ Miss rate >50% — MT-12 hypothesis under stress; consider IMP-9 (conservative mode)."
+        )
     elif miss_rate < 20:
         print("  ✅ Miss rate <20% — TCP filtering is helping more than hurting.")
     else:
         print("  → Miss rate in 20-50% range — ambiguous; more data needed.")
 
     if window_hours >= args.min_hours:
-        print(f"\n✅ Window complete ({window_hours:.2f}h ≥ {args.min_hours}h). Results are final.")
+        print(
+            f"\n✅ Window complete ({window_hours:.2f}h ≥ {args.min_hours}h). Results are final."
+        )
     else:
         remaining = args.min_hours - window_hours
         print(f"\n⏳ Re-run in ~{remaining:.1f}h for final results.")

--- a/scripts/run-lightweight-demo.py
+++ b/scripts/run-lightweight-demo.py
@@ -9,10 +9,14 @@ import json
 from pathlib import Path
 
 # Add tcp modules to path
-sys.path.insert(0, '/tcp-security')
+sys.path.insert(0, "/tcp-security")
 
 try:
-    from tcp.enrichment.manpage_enricher import ManPageEnricher, SecurityLevel, PrivilegeLevel
+    from tcp.enrichment.manpage_enricher import (
+        ManPageEnricher,
+        SecurityLevel,
+        PrivilegeLevel,
+    )
     from tcp.enrichment.tcp_encoder import EnrichedTCPEncoder, SecurityFlags
     from tcp.enrichment.risk_assessment_auditor import TransparentRiskAssessor
     from tcp.local_ollama_demo import OllamaLLMProcessor
@@ -20,90 +24,107 @@ except ImportError as e:
     print(f"Import error: {e}")
     print("Running basic demonstration without full imports...")
 
+
 def lightweight_system_encode():
     """Run complete system encode with lightweight LLM."""
-    
+
     print("🧠 LIGHTWEIGHT TCP SECURITY SYSTEM ENCODE")
     print("=" * 60)
     print("Using llama3.2:1b for fast local LLM processing")
     print()
-    
+
     # Initialize components with lightweight model
     try:
         llm = OllamaLLMProcessor(model_name="llama3.2:1b")
         enricher = ManPageEnricher()
         encoder = EnrichedTCPEncoder(enricher)
         assessor = TransparentRiskAssessor()
-        
+
         print(f"✅ LLM Available: {llm.available}")
         print(f"✅ Model: {llm.model_name}")
         print()
-        
+
     except Exception as e:
         print(f"⚠️  Component initialization failed: {e}")
         print("Continuing with basic demonstration...")
         return basic_demonstration()
-    
+
     # Test commands for full system encode
     commands = [
         # Safe commands
-        'cat', 'grep', 'head', 'tail', 'less',
+        "cat",
+        "grep",
+        "head",
+        "tail",
+        "less",
         # Medium risk
-        'cp', 'mv', 'curl', 'tar', 'ssh',
+        "cp",
+        "mv",
+        "curl",
+        "tar",
+        "ssh",
         # High risk
-        'chmod', 'chown', 'kill', 'mount',
+        "chmod",
+        "chown",
+        "kill",
+        "mount",
         # Critical
-        'rm', 'dd', 'sudo', 'fdisk'
+        "rm",
+        "dd",
+        "sudo",
+        "fdisk",
     ]
-    
+
     print(f"🔍 Processing {len(commands)} commands through complete pipeline...")
     print()
-    
+
     results = {}
-    
+
     for i, command in enumerate(commands, 1):
         print(f"[{i:2d}/{len(commands)}] {command}")
         print("-" * 30)
-        
+
         try:
             # Step 1: Man page enrichment
             print("  1️⃣ Man page enrichment...")
             man_data = enricher.enrich_command(command)
-            
+
             if not man_data:
                 print(f"     ❌ No man page for {command}")
                 continue
-            
+
             print(f"     ✅ Security: {man_data.security_level.value}")
             print(f"     ✅ Privileges: {man_data.privilege_requirements.value}")
-            
+
             # Step 2: Local LLM analysis
             print("  2️⃣ Local LLM analysis...")
             man_content = enricher.get_local_manpage(command) or ""
-            llm_analysis = llm.analyze_command_security(command, man_content[:1000])  # Truncate for speed
-            
+            llm_analysis = llm.analyze_command_security(
+                command, man_content[:1000]
+            )  # Truncate for speed
+
             print(f"     ✅ LLM Risk: {llm_analysis.get('risk_score', 0):.2f}")
-            
+
             # Step 3: Enhanced TCP encoding
             print("  3️⃣ TCP encoding...")
             descriptor = encoder.encode_enhanced_tcp(command)
             binary_data = encoder.to_binary(descriptor)
-            
+
             print(f"     ✅ Binary: {len(binary_data)} bytes")
             print(f"     ✅ Flags: 0x{descriptor.security_flags:08x}")
-            
+
             # Step 4: Risk assessment
             print("  4️⃣ Risk assessment...")
             audit = assessor.assess_command_risk(command, man_data)
-            
+
             print(f"     ✅ Score: {audit.security_score:.3f}")
             print(f"     ✅ Evidence: {len(audit.risk_evidence)} pieces")
-            
+
             # Step 5: Naive agent understanding
             print("  5️⃣ Agent analysis...")
             flags = descriptor.security_flags
             agent_insights = []
-            
+
             if flags & (1 << SecurityFlags.CRITICAL):
                 agent_insights.append("💀 CRITICAL")
             elif flags & (1 << SecurityFlags.HIGH_RISK):
@@ -112,58 +133,63 @@ def lightweight_system_encode():
                 agent_insights.append("🟠 MEDIUM")
             else:
                 agent_insights.append("🟢 SAFE")
-            
+
             if flags & (1 << SecurityFlags.DESTRUCTIVE):
                 agent_insights.append("💥 Destructive")
             if flags & (1 << SecurityFlags.REQUIRES_ROOT):
                 agent_insights.append("🔑 Root")
             elif flags & (1 << SecurityFlags.REQUIRES_SUDO):
                 agent_insights.append("🔐 Sudo")
-            
+
             print(f"     🤖 Agent: {' '.join(agent_insights)}")
-            
+
             # Store results
             results[command] = {
-                'security_level': man_data.security_level.value,
-                'privilege_level': man_data.privilege_requirements.value,
-                'llm_risk': llm_analysis.get('risk_score', 0),
-                'tcp_size': len(binary_data),
-                'security_flags': f"0x{descriptor.security_flags:08x}",
-                'audit_score': audit.security_score,
-                'evidence_count': len(audit.risk_evidence),
-                'agent_insights': agent_insights
+                "security_level": man_data.security_level.value,
+                "privilege_level": man_data.privilege_requirements.value,
+                "llm_risk": llm_analysis.get("risk_score", 0),
+                "tcp_size": len(binary_data),
+                "security_flags": f"0x{descriptor.security_flags:08x}",
+                "audit_score": audit.security_score,
+                "evidence_count": len(audit.risk_evidence),
+                "agent_insights": agent_insights,
             }
-            
+
             print()
-            
+
         except Exception as e:
             print(f"     ❌ Error processing {command}: {e}")
             print()
             continue
-    
+
     # Generate summary report
     print("📊 FULL SYSTEM ENCODE SUMMARY")
     print("=" * 60)
-    
+
     if results:
         # Security level distribution
         security_levels = {}
         for cmd, data in results.items():
-            level = data['security_level']
+            level = data["security_level"]
             security_levels[level] = security_levels.get(level, 0) + 1
-        
+
         print("Security Classification:")
         for level, count in sorted(security_levels.items()):
             print(f"   {level}: {count} commands")
-        
+
         print()
         print("Sample High-Risk Commands:")
-        high_risk = [(cmd, data) for cmd, data in results.items() 
-                    if data['security_level'] in ['high_risk', 'critical']]
-        
+        high_risk = [
+            (cmd, data)
+            for cmd, data in results.items()
+            if data["security_level"] in ["high_risk", "critical"]
+        ]
+
         for cmd, data in high_risk[:5]:
-            print(f"   {cmd:8} | {data['security_level']:12} | {data['security_flags']} | {' '.join(data['agent_insights'])}")
-        
+            print(
+                f"   {cmd:8} | {data['security_level']:12} | {data['security_flags']} | {' '.join(data['agent_insights'])}"
+            )
+
         print()
         print("🎯 KEY ACHIEVEMENTS:")
         print(f"   ✅ Commands processed: {len(results)}")
@@ -171,33 +197,35 @@ def lightweight_system_encode():
         print(f"   ✅ Binary compression: 24 bytes vs ~3KB help text")
         print(f"   ✅ Agent understanding: Direct from binary flags")
         print(f"   ✅ Human oversight: Zero-trust architecture ready")
-        
+
         # Save results
-        with open('/tcp-security/lightweight_encode_results.json', 'w') as f:
+        with open("/tcp-security/lightweight_encode_results.json", "w") as f:
             json.dump(results, f, indent=2, default=str)
-        
+
         print(f"   ✅ Results saved: lightweight_encode_results.json")
-        
+
     else:
         print("❌ No results generated")
-    
+
     print()
     print("🏁 LIGHTWEIGHT SYSTEM ENCODE COMPLETE!")
     print("Full TCP security intelligence with local LLM processing")
+
 
 def basic_demonstration():
     """Basic demonstration without full imports."""
     print("🔧 BASIC TCP DEMONSTRATION")
     print("=" * 40)
     print("Running simplified version due to import issues...")
-    
-    commands = ['cat', 'rm', 'sudo', 'curl']
-    
+
+    commands = ["cat", "rm", "sudo", "curl"]
+
     for command in commands:
         print(f"Command: {command}")
         print(f"  Status: Would analyze with TCP system")
         print(f"  Binary: 24 bytes with embedded security")
         print()
+
 
 if __name__ == "__main__":
     lightweight_system_encode()

--- a/scripts/run_exp6.py
+++ b/scripts/run_exp6.py
@@ -17,9 +17,7 @@ from pathlib import Path
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="TCP-EXP-6: Primacy-bias experiment"
-    )
+    parser = argparse.ArgumentParser(description="TCP-EXP-6: Primacy-bias experiment")
     parser.add_argument(
         "--model",
         default="claude-sonnet-4-6",
@@ -85,11 +83,17 @@ def main() -> None:
     print(f"    mean latency ms        : {cn['mean_latency_ms']:.0f}")
     print(f"    error rate             : {cn['error_rate']:.1%}")
     print()
-    print(f"  Delta first-tool correctness  : {bias['delta_first_tool_correctness']:+.1%}")
-    print(f"  Delta any-position correctness: {bias['delta_any_position_correctness']:+.1%}")
+    print(
+        f"  Delta first-tool correctness  : {bias['delta_first_tool_correctness']:+.1%}"
+    )
+    print(
+        f"  Delta any-position correctness: {bias['delta_any_position_correctness']:+.1%}"
+    )
     print()
     if bias["stop_condition_met"]:
-        print("  [STOP CONDITION] any-position delta < 1pp — ordering has no material effect")
+        print(
+            "  [STOP CONDITION] any-position delta < 1pp — ordering has no material effect"
+        )
     else:
         print("  [RESULT] any-position delta ≥ 1pp — primacy bias detected")
 

--- a/scripts/shadow_analysis.py
+++ b/scripts/shadow_analysis.py
@@ -58,7 +58,9 @@ def main() -> None:
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--session", help="Path to a single session JSONL file")
     group.add_argument("--all", action="store_true", help="Analyse all sessions")
-    group.add_argument("--audit", action="store_true", help="Run 20-turn kill condition audit")
+    group.add_argument(
+        "--audit", action="store_true", help="Run 20-turn kill condition audit"
+    )
     args = parser.parse_args()
 
     if args.session:
@@ -75,12 +77,16 @@ def main() -> None:
 
 def analyse_session(session_path: Path) -> list[CallResult]:
     from tcp.derivation.request_derivation import (
-        SessionStartEvent, PostToolUseEvent,
-        classify_unscorable, get_equivalence_class,
+        SessionStartEvent,
+        PostToolUseEvent,
+        classify_unscorable,
+        get_equivalence_class,
     )
     from tcp.harness.models import ToolRecord
 
-    records = [json.loads(l) for l in session_path.read_text().splitlines() if l.strip()]
+    records = [
+        json.loads(l) for l in session_path.read_text().splitlines() if l.strip()
+    ]
 
     # Extract session metadata
     session_start = next((r for r in records if r["event"] == "session_start"), None)
@@ -102,20 +108,23 @@ def analyse_session(session_path: Path) -> list[CallResult]:
         inv = json.loads(inventory_path.read_text())
         inventory_available = bool(inv.get("tools"))
         for t in inv.get("tools", []):
-            tool_records.append(ToolRecord(
-                tool_name=t["name"],
-                descriptor_source="shadow",
-                descriptor_version=str(inv.get("version", "unknown")),
-                capability_flags=t.get("flags", 0),
-                risk_level="safe",
-            ))
+            tool_records.append(
+                ToolRecord(
+                    tool_name=t["name"],
+                    descriptor_source="shadow",
+                    descriptor_version=str(inv.get("version", "unknown")),
+                    capability_flags=t.get("flags", 0),
+                    risk_level="safe",
+                )
+            )
 
     full_inventory_size = len(tool_records)
 
     # Build prompt lookup by turn_id
     prompts: dict[int, tuple[str, float]] = {
         r["turn_id"]: (r["prompt"], float(r.get("timestamp", 0.0)))
-        for r in records if r["event"] == "user_prompt"
+        for r in records
+        if r["event"] == "user_prompt"
     }
 
     results = []
@@ -140,7 +149,9 @@ def analyse_session(session_path: Path) -> list[CallResult]:
 
         # Unscorable check
         unscorable = classify_unscorable(prompt, tool_event)
-        unscorable_reason = _unscorable_reason(prompt, tool_event) if unscorable else None
+        unscorable_reason = (
+            _unscorable_reason(prompt, tool_event) if unscorable else None
+        )
 
         exclusion_reason = None
         decision = None
@@ -158,55 +169,59 @@ def analyse_session(session_path: Path) -> list[CallResult]:
                 exclusion_reason = "incomplete_turn_context"
 
         if unscorable or exclusion_reason is not None:
-            results.append(CallResult(
-                session_id=r["session_id"],
-                turn_id=turn_id,
-                call_id=r.get("call_id", ""),
-                tool_name=tool_name,
-                equivalence_class=equiv_class,
-                prompt=prompt[:120],
-                unscorable=unscorable,
-                unscorable_reason=unscorable_reason,
-                in_survivor_set=None,
-                survivor_count=None,
-                full_inventory_tokens=None,
-                filtered_inventory_tokens=None,
-                token_delta=None,
-                benchmark_eligible=False,
-                exclusion_reason=exclusion_reason,
-            ))
+            results.append(
+                CallResult(
+                    session_id=r["session_id"],
+                    turn_id=turn_id,
+                    call_id=r.get("call_id", ""),
+                    tool_name=tool_name,
+                    equivalence_class=equiv_class,
+                    prompt=prompt[:120],
+                    unscorable=unscorable,
+                    unscorable_reason=unscorable_reason,
+                    in_survivor_set=None,
+                    survivor_count=None,
+                    full_inventory_tokens=None,
+                    filtered_inventory_tokens=None,
+                    token_delta=None,
+                    benchmark_eligible=False,
+                    exclusion_reason=exclusion_reason,
+                )
+            )
             continue
 
         survivors = set(decision.get("survivor_names_sorted") or [])
 
         # Coverage: does survivor set contain a tool in the same equivalence class?
         from tcp.derivation.request_derivation import get_equivalence_class as geq
+
         in_survivor = any(
-            geq(s, {}) == equiv_class or s == tool_name
-            for s in survivors
+            geq(s, {}) == equiv_class or s == tool_name for s in survivors
         )
 
         full_tokens = full_inventory_size * FULL_DESC_CHARS // CHARS_PER_TOKEN
         filtered_tokens = len(survivors) * MINIMAL_DESC_CHARS // CHARS_PER_TOKEN
         token_delta = full_tokens - filtered_tokens
 
-        results.append(CallResult(
-            session_id=r["session_id"],
-            turn_id=turn_id,
-            call_id=r.get("call_id", ""),
-            tool_name=tool_name,
-            equivalence_class=equiv_class,
-            prompt=prompt[:120],
-            unscorable=False,
-            unscorable_reason=None,
-            in_survivor_set=in_survivor,
-            survivor_count=len(survivors),
-            full_inventory_tokens=full_tokens,
-            filtered_inventory_tokens=filtered_tokens,
-            token_delta=token_delta,
-            benchmark_eligible=True,
-            exclusion_reason=None,
-        ))
+        results.append(
+            CallResult(
+                session_id=r["session_id"],
+                turn_id=turn_id,
+                call_id=r.get("call_id", ""),
+                tool_name=tool_name,
+                equivalence_class=equiv_class,
+                prompt=prompt[:120],
+                unscorable=False,
+                unscorable_reason=None,
+                in_survivor_set=in_survivor,
+                survivor_count=len(survivors),
+                full_inventory_tokens=full_tokens,
+                filtered_inventory_tokens=filtered_tokens,
+                token_delta=token_delta,
+                benchmark_eligible=True,
+                exclusion_reason=None,
+            )
+        )
 
     return results
 
@@ -232,7 +247,9 @@ def print_report(results: list[CallResult]) -> None:
 
     covered = sum(1 for r in benchmark_rows if r.in_survivor_set)
     coverage = covered / len(benchmark_rows)
-    mean_delta = sum(r.token_delta for r in benchmark_rows if r.token_delta) / len(benchmark_rows)
+    mean_delta = sum(r.token_delta for r in benchmark_rows if r.token_delta) / len(
+        benchmark_rows
+    )
     unscorable_rate = n_unscorable / total if total else 0
     excluded_rate = n_excluded / len(scorable) if scorable else 0
 
@@ -347,7 +364,9 @@ def run_audit() -> None:
     print(f"{'#':<3} {'Tool':<30} {'Class':<18} {'In Surv':>8}  Prompt")
     print("-" * 100)
     for i, r in enumerate(sample, 1):
-        print(f"{i:<3} {r.tool_name:<30} {r.equivalence_class:<18} {str(r.in_survivor_set):>8}  {r.prompt[:40]}")
+        print(
+            f"{i:<3} {r.tool_name:<30} {r.equivalence_class:<18} {str(r.in_survivor_set):>8}  {r.prompt[:40]}"
+        )
 
     auto_coverage = sum(1 for r in sample if r.in_survivor_set) / 20
     print(f"\nAuto-derived coverage on sample: {auto_coverage:.0%}")
@@ -356,8 +375,11 @@ def run_audit() -> None:
 
 def _unscorable_reason(prompt: str, tool_event) -> str:
     from tcp.derivation.request_derivation import (
-        _SYSTEM_TOOLS, _CONTINUATION_PROMPTS, _derive_capability_flags_from_prompt_only
+        _SYSTEM_TOOLS,
+        _CONTINUATION_PROMPTS,
+        _derive_capability_flags_from_prompt_only,
     )
+
     if tool_event.tool_name in _SYSTEM_TOOLS:
         return "system_tool"
     stripped = prompt.strip().lower()

--- a/scripts/tcp_data_1_calibration.py
+++ b/scripts/tcp_data_1_calibration.py
@@ -114,8 +114,12 @@ def main() -> None:
         "report",
         help="Write a calibration status markdown report for an existing JSONL file.",
     )
-    report.add_argument("--jsonl", type=Path, required=True, help="Calibration JSONL path")
-    report.add_argument("--output", type=Path, required=True, help="Markdown report path")
+    report.add_argument(
+        "--jsonl", type=Path, required=True, help="Calibration JSONL path"
+    )
+    report.add_argument(
+        "--output", type=Path, required=True, help="Markdown report path"
+    )
 
     tui = subparsers.add_parser(
         "rater2-tui",
@@ -156,7 +160,9 @@ def main() -> None:
         return
     if args.command == "report":
         rows = load_rows(args.jsonl)
-        args.output.write_text(render_report(rows, source_name=args.jsonl.name), encoding="utf-8")
+        args.output.write_text(
+            render_report(rows, source_name=args.jsonl.name), encoding="utf-8"
+        )
         print(f"Wrote calibration report to {args.output}")
         return
     if args.command == "rater2-tui":
@@ -193,7 +199,10 @@ def advance_rater1(package_dir: Path) -> None:
     synced = sync_rows_by_key(calibration_rows, candidate_rows)
     save_rows(candidate_path, candidate_rows)
 
-    status_path.write_text(render_report(calibration_rows, source_name=calibration_path.name), encoding="utf-8")
+    status_path.write_text(
+        render_report(calibration_rows, source_name=calibration_path.name),
+        encoding="utf-8",
+    )
 
     print(f"Applied rater1 seed to {len(RATER1_CALIBRATION_SEED)} calibration rows.")
     print(f"Synced {synced} rows back into {candidate_path}.")
@@ -229,7 +238,9 @@ def rater2_tui(package_dir: Path) -> None:
 
             while True:
                 try:
-                    raw_flags = input("Flags (int sum, e.g. 1 for FILES, 4 for NETWORK): ").strip()
+                    raw_flags = input(
+                        "Flags (int sum, e.g. 1 for FILES, 4 for NETWORK): "
+                    ).strip()
                     if not raw_flags:
                         flags = 0
                     else:
@@ -239,7 +250,9 @@ def rater2_tui(package_dir: Path) -> None:
                     print("Invalid integer. Please try again.")
 
             formats_str = input("Formats (comma-separated, default 'text'): ").strip()
-            formats = [f.strip() for f in formats_str.split(",") if f.strip()] or ["text"]
+            formats = [f.strip() for f in formats_str.split(",") if f.strip()] or [
+                "text"
+            ]
 
             notes = input("Notes: ").strip()
 
@@ -263,7 +276,9 @@ def rater2_tui(package_dir: Path) -> None:
     synced = sync_rows_by_key(rows, candidate_rows)
     save_rows(candidate_path, candidate_rows)
 
-    status_path.write_text(render_report(rows, source_name=calibration_path.name), encoding="utf-8")
+    status_path.write_text(
+        render_report(rows, source_name=calibration_path.name), encoding="utf-8"
+    )
 
     print(f"Saved {len(rows)} rows to {calibration_path}.")
     print(f"Synced {synced} rows back into {candidate_path}.")
@@ -294,12 +309,18 @@ def adjudicate_tui(package_dir: Path) -> None:
             print(f"Session: {row['session_id']} Turn: {row['turn_id']}")
             print(f"Prompt: {row['prompt']}")
             print(f"Tools:  {row.get('observed_tool_names', [])}")
-            print(f"Rater 1: Flags={row['rater1_flags']}, Formats={row['rater1_formats']}, Notes={row['rater1_notes']}")
-            print(f"Rater 2: Flags={row['rater2_flags']}, Formats={row['rater2_formats']}, Notes={row['rater2_notes']}")
+            print(
+                f"Rater 1: Flags={row['rater1_flags']}, Formats={row['rater1_formats']}, Notes={row['rater1_notes']}"
+            )
+            print(
+                f"Rater 2: Flags={row['rater2_flags']}, Formats={row['rater2_formats']}, Notes={row['rater2_notes']}"
+            )
             print("")
 
             while True:
-                choice = input("Resolve with [1] Rater 1, [2] Rater 2, or [3] Custom? ").strip()
+                choice = input(
+                    "Resolve with [1] Rater 1, [2] Rater 2, or [3] Custom? "
+                ).strip()
                 if choice == "1":
                     flags = row["rater1_flags"]
                     formats = row["rater1_formats"]
@@ -319,7 +340,9 @@ def adjudicate_tui(package_dir: Path) -> None:
                         except ValueError:
                             print("Invalid integer.")
                     formats_str = input("Custom Formats (comma-separated): ").strip()
-                    formats = [f.strip() for f in formats_str.split(",") if f.strip()] or ["text"]
+                    formats = [
+                        f.strip() for f in formats_str.split(",") if f.strip()
+                    ] or ["text"]
                     notes = input("Adjudication Notes: ").strip()
                     break
                 else:
@@ -345,7 +368,9 @@ def adjudicate_tui(package_dir: Path) -> None:
     synced = sync_rows_by_key(rows, candidate_rows)
     save_rows(candidate_path, candidate_rows)
 
-    status_path.write_text(render_report(rows, source_name=calibration_path.name), encoding="utf-8")
+    status_path.write_text(
+        render_report(rows, source_name=calibration_path.name), encoding="utf-8"
+    )
 
     print(f"Saved {len(rows)} rows to {calibration_path}.")
     print(f"Synced {synced} rows back into {candidate_path}.")
@@ -384,7 +409,9 @@ def finalize_rater1(package_dir: Path) -> None:
                     print("Invalid integer.")
 
             formats_str = input("Formats (comma-separated, default 'text'): ").strip()
-            formats = [f.strip() for f in formats_str.split(",") if f.strip()] or ["text"]
+            formats = [f.strip() for f in formats_str.split(",") if f.strip()] or [
+                "text"
+            ]
             notes = input("Notes: ").strip()
 
             # For single-rater final pass, we apply to rater1 then immediately mark as final
@@ -401,7 +428,10 @@ def finalize_rater1(package_dir: Path) -> None:
             # Find the row again in the full list to update its status to final
             # (apply_rating updates state but might not set 'final' if rater2 is missing)
             for r in rows:
-                if r["session_id"] == row["session_id"] and r["turn_id"] == row["turn_id"]:
+                if (
+                    r["session_id"] == row["session_id"]
+                    and r["turn_id"] == row["turn_id"]
+                ):
                     r["label_status"] = "final"
                     r["final_flags"] = flags
                     r["final_formats"] = formats
@@ -444,7 +474,9 @@ def render_report(rows: list[dict[str, object]], *, source_name: str) -> str:
         "## Status Counts",
         "",
     ]
-    lines.extend(f"- `{status}`: {count}" for status, count in summary.status_counts.items())
+    lines.extend(
+        f"- `{status}`: {count}" for status, count in summary.status_counts.items()
+    )
     lines.extend(
         [
             "",

--- a/scripts/tcp_shadow_prompt.py
+++ b/scripts/tcp_shadow_prompt.py
@@ -46,7 +46,8 @@ def _next_turn_id(log_path: Path) -> int:
     if not log_path.exists():
         return 1
     count = sum(
-        1 for line in log_path.read_text().splitlines()
+        1
+        for line in log_path.read_text().splitlines()
         if line and json.loads(line).get("event") == "user_prompt"
     )
     return count + 1

--- a/scripts/tcp_shadow_tool.py
+++ b/scripts/tcp_shadow_tool.py
@@ -19,10 +19,10 @@ from pathlib import Path
 
 SESSIONS_DIR = Path.home() / ".tcp-shadow" / "sessions"
 
-_URL_RE = re.compile(r'https?://\S+')
-_SQL_RE = re.compile(r'\b(SELECT|INSERT|UPDATE|DELETE|FROM|WHERE)\b', re.IGNORECASE)
+_URL_RE = re.compile(r"https?://\S+")
+_SQL_RE = re.compile(r"\b(SELECT|INSERT|UPDATE|DELETE|FROM|WHERE)\b", re.IGNORECASE)
 _PATH_RE = re.compile(r'(^|[\s\'"])(\/[\w/.-]+|\.\./[\w/.-]+)')
-_REGEX_RE = re.compile(r'[.*+?^${}()|[\]\\]')
+_REGEX_RE = re.compile(r"[.*+?^${}()|[\]\\]")
 
 
 def main() -> None:
@@ -84,7 +84,9 @@ def _extract_features(tool_input: dict) -> dict:
         "has_sql": bool(_SQL_RE.search(text)),
         "has_regex": bool(_REGEX_RE.search(text)),
         "arg_size_bucket": _size_bucket(len(text)),
-        "top_level_keys": sorted(tool_input.keys()) if isinstance(tool_input, dict) else [],
+        "top_level_keys": sorted(tool_input.keys())
+        if isinstance(tool_input, dict)
+        else [],
     }
 
 
@@ -102,7 +104,8 @@ def _current_turn_id(log_path: Path) -> int:
     if not log_path.exists():
         return 1
     prompts = [
-        json.loads(l) for l in log_path.read_text().splitlines()
+        json.loads(l)
+        for l in log_path.read_text().splitlines()
         if l and json.loads(l).get("event") == "user_prompt"
     ]
     return prompts[-1]["turn_id"] if prompts else 1

--- a/tcp/analysis/pipeline.py
+++ b/tcp/analysis/pipeline.py
@@ -159,9 +159,9 @@ class TCPGenerationPipeline:
                 if output_format == "tcp":
                     results["outputs"]["tcp"] = tcp_descriptor
                 elif output_format == "json":
-                    results["outputs"]["json"] = (
-                        self.tcp_generator.generate_json_schema(capabilities)
-                    )
+                    results["outputs"][
+                        "json"
+                    ] = self.tcp_generator.generate_json_schema(capabilities)
                 elif output_format == "binary":
                     binary_data = self.tcp_generator.generate_binary_descriptor(
                         capabilities

--- a/tcp/analysis/statistical_performance_engine.py
+++ b/tcp/analysis/statistical_performance_engine.py
@@ -636,13 +636,13 @@ class StatisticalPerformanceEngine:
         )
 
     @staticmethod
-    @numba.jit(nopython=True) if NUMBA_AVAILABLE else lambda f: f
+    @ numba.jit(nopython=True) if NUMBA_AVAILABLE else lambda f: f
     def _numba_mean(arr: np.ndarray) -> float:
         """Numba-optimized mean calculation."""
         return np.mean(arr)
 
     @staticmethod
-    @numba.jit(nopython=True) if NUMBA_AVAILABLE else lambda f: f
+    @ numba.jit(nopython=True) if NUMBA_AVAILABLE else lambda f: f
     def _numba_variance(arr: np.ndarray, mean: float) -> float:
         """Numba-optimized variance calculation."""
         return np.var(arr - mean)
@@ -674,7 +674,9 @@ class StatisticalPerformanceEngine:
         s2_sq_n2 = stats2.variance / stats2.count
 
         df_num = (s1_sq_n1 + s2_sq_n2) ** 2
-        df_denom = s1_sq_n1**2 / (stats1.count - 1) + s2_sq_n2**2 / (stats2.count - 1)
+        df_denom = s1_sq_n1**2 / (stats1.count - 1) + s2_sq_n2**2 / (
+            stats2.count - 1
+        )
 
         if df_denom == 0:
             return 1.0

--- a/tcp/cli_selftest.py
+++ b/tcp/cli_selftest.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import List
 
 from .core.snf import SNFCanonicalizer
-from .core.tlv_evidence import compute_evidence_id
 from .core.telemetry import record_hist
+from .core.tlv_evidence import compute_evidence_id
 
 
 def _load_pairs(path: str) -> List[dict]:

--- a/tcp/core/__init__.py
+++ b/tcp/core/__init__.py
@@ -10,9 +10,9 @@ from .descriptors import (
 from .discovery import DiscoveryService
 from .protocol import ToolCapabilityProtocol
 from .registry import CapabilityRegistry
+from .signing_surface import canonical_bytes_without_evidence
 from .snf import SNFCanonicalizer, SNFError
 from .telemetry import record_hist
-from .signing_surface import canonical_bytes_without_evidence
 
 # The TLV helpers depend on optional CBOR support. Keep the rest of the TCP
 # package importable even when that extra dependency is absent.

--- a/tcp/core/semantic_routing.py
+++ b/tcp/core/semantic_routing.py
@@ -328,9 +328,9 @@ class SemanticRoutingEngine:
         self.path_success_rates: Dict[str, float] = defaultdict(lambda: 1.0)
 
         # Adaptive learning
-        self.content_routing_patterns: Dict[ContentType, Dict[str, float]] = (
-            defaultdict(dict)
-        )
+        self.content_routing_patterns: Dict[
+            ContentType, Dict[str, float]
+        ] = defaultdict(dict)
         self.behavioral_routing_adjustments: Dict[str, float] = defaultdict(float)
 
         # Register default routing strategies

--- a/tcp/core/signing_surface.py
+++ b/tcp/core/signing_surface.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import copy
 import struct
-from typing import Tuple
-
 import zlib
+from typing import Tuple
 
 EVIDENCE_TYPE = 0x000B
 
@@ -31,11 +30,11 @@ def canonical_bytes_without_evidence(descriptor_bytes: bytes) -> bytes:
     out = bytearray()
     offset = 0
     while offset < len(tlv_data):
-        t, f, l = struct.unpack_from("<HHI", tlv_data, offset)
-        payload = tlv_data[offset : offset + 8 + l]
+        t, _flags, length = struct.unpack_from("<HHI", tlv_data, offset)
+        payload = tlv_data[offset : offset + 8 + length]
         if t != EVIDENCE_TYPE:
             out.extend(payload)
-        offset += 8 + l
+        offset += 8 + length
     new_total = 32 + len(out)
     struct.pack_into("<Q", header, 16, new_total)
     # zero CRC32C then compute

--- a/tcp/derivation/audit_contract.py
+++ b/tcp/derivation/audit_contract.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-import sys
 from typing import Any, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tcp/enrichment/risk_assessment_auditor.py
+++ b/tcp/enrichment/risk_assessment_auditor.py
@@ -899,7 +899,9 @@ class TransparentRiskAssessor:
                 risk_level = (
                     "HIGH"
                     if evidence.risk_contribution >= 0.7
-                    else "MED" if evidence.risk_contribution >= 0.4 else "LOW"
+                    else "MED"
+                    if evidence.risk_contribution >= 0.4
+                    else "LOW"
                 )
                 report_lines.append(f"  [{risk_level}] {evidence.evidence_text}")
                 report_lines.append(

--- a/tcp/harness/__init__.py
+++ b/tcp/harness/__init__.py
@@ -1,12 +1,6 @@
 """TCP harness primitives for descriptor-native tool routing."""
 
 from .audit import AuditEntry, GatingDecision
-from .bitmask_filter import (
-    BitmaskFilterResult,
-    EnvironmentMask,
-    bitmask_filter,
-    filter_for_prompt,
-)
 from .benchmark import (
     BenchmarkComparison,
     BenchmarkSuiteResult,
@@ -15,6 +9,12 @@ from .benchmark import (
     benchmark_exposure_suite,
     build_mt2_fixture_set,
     summarize_comparisons,
+)
+from .bitmask_filter import (
+    BitmaskFilterResult,
+    EnvironmentMask,
+    bitmask_filter,
+    filter_for_prompt,
 )
 from .gating import GateResult, RuntimeEnvironment, gate_tools
 from .models import ToolRecord, ToolSelectionRequest

--- a/tcp/harness/benchmark_mt3.py
+++ b/tcp/harness/benchmark_mt3.py
@@ -13,7 +13,7 @@ from tcp.harness.benchmark import (
     benchmark_exposure_suite,
     summarize_comparisons,
 )
-from tcp.harness.corpus import build_mt3_corpus, corpus_summary, CorpusEntry
+from tcp.harness.corpus import CorpusEntry, build_mt3_corpus, corpus_summary
 from tcp.harness.gating import RuntimeEnvironment
 from tcp.harness.models import ToolSelectionRequest
 

--- a/tcp/harness/run_benchmark.py
+++ b/tcp/harness/run_benchmark.py
@@ -72,10 +72,7 @@ def main() -> int:
 
 
 def _run_mt2(repetitions: int) -> dict:
-    from tcp.harness.benchmark import (
-        benchmark_exposure_suite,
-        build_mt2_fixture_set,
-    )
+    from tcp.harness.benchmark import benchmark_exposure_suite, build_mt2_fixture_set
 
     descriptors, tasks, environment = build_mt2_fixture_set()
     suite = benchmark_exposure_suite(

--- a/tcp/harness/schema_bridge.py
+++ b/tcp/harness/schema_bridge.py
@@ -9,11 +9,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from tcp.core.descriptors import (
-    CapabilityDescriptor,
-    CapabilityFlags,
-    ParameterType,
-)
+from tcp.core.descriptors import CapabilityDescriptor, CapabilityFlags, ParameterType
 from tcp.harness.corpus import CorpusEntry
 from tcp.harness.models import ToolRecord
 

--- a/tcp/proxy/absence_language.py
+++ b/tcp/proxy/absence_language.py
@@ -8,54 +8,129 @@ from __future__ import annotations
 
 import re
 
-
 _ABSENCE_PATTERNS: tuple[re.Pattern[str], ...] = (
     # First-person inability — original 11 patterns
     re.compile(r"\bI (?:do not|don't) have access to\b", re.I),
     re.compile(r"\bI (?:can't|cannot) access\b", re.I),
     re.compile(r"\bI (?:can't|cannot) reach\b", re.I),
-    re.compile(r"\bI (?:do not|don't) have (?:a |the )?(?:tool|connector|integration|plugin) for\b", re.I),
+    re.compile(
+        r"\bI (?:do not|don't) have (?:a |the )?(?:tool|connector|integration|plugin) for\b",
+        re.I,
+    ),
     re.compile(r"\bno (?:tool|connector|integration) (?:is )?available for\b", re.I),
     re.compile(r"\bI(?:'m| am) not able to (?:access|reach|connect to|use)\b", re.I),
-    re.compile(r"\bI (?:do not|don't) have (?:the )?ability to (?:access|reach|connect to)\b", re.I),
-    re.compile(r"\bI (?:do not|don't) have (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear)\b", re.I),
-    re.compile(r"\bno (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) (?:tool|access|connector|integration)\b", re.I),
-    re.compile(r"\bI (?:can't|cannot) (?:search|query|access|read|write|fetch) (?:your |the )?(?:Notion|GitHub|calendar|email|database)\b", re.I),
-    re.compile(r"\bI don't have (?:direct )?access to (?:any )?(?:external|connected|linked)\b", re.I),
+    re.compile(
+        r"\bI (?:do not|don't) have (?:the )?ability to (?:access|reach|connect to)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bI (?:do not|don't) have (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bno (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) (?:tool|access|connector|integration)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bI (?:can't|cannot) (?:search|query|access|read|write|fetch) (?:your |the )?(?:Notion|GitHub|calendar|email|database)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bI don't have (?:direct )?access to (?:any )?(?:external|connected|linked)\b",
+        re.I,
+    ),
     # Verb alternatives — "lack", "no way to", "have no"
-    re.compile(r"\bI lack (?:the )?(?:access|ability|capability|means|tool|tools|way) (?:to|for)\b", re.I),
+    re.compile(
+        r"\bI lack (?:the )?(?:access|ability|capability|means|tool|tools|way) (?:to|for)\b",
+        re.I,
+    ),
     re.compile(r"\bI lack access\b", re.I),
     re.compile(r"\bI have no (?:way|means|access|ability|tool|tools) to\b", re.I),
     re.compile(r"\bI (?:do not|don't) support\b", re.I),
     # Subject-inversion / impersonal — capability-token subject
-    re.compile(r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear)(?:\s+\w+){0,3}\s+is (?:not |un)(?:accessible|available|connected|reachable|supported)\b", re.I),
-    re.compile(r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) integration is (?:not |un)(?:available|connected|enabled|configured|accessible)\b", re.I),
-    re.compile(r"\b(?:the )?(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) integration (?:is(?:n't| not)|isn't) (?:available|enabled|connected|configured)\b", re.I),
+    re.compile(
+        r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear)(?:\s+\w+){0,3}\s+is (?:not |un)(?:accessible|available|connected|reachable|supported)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) integration is (?:not |un)(?:available|connected|enabled|configured|accessible)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:the )?(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear) integration (?:is(?:n't| not)|isn't) (?:available|enabled|connected|configured)\b",
+        re.I,
+    ),
     # Existential negation — "There is no X"
-    re.compile(r"\bthere(?:'s| is) no (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear|tool|connector|integration|capability|way)\b", re.I),
-    re.compile(r"\bthere are no (?:tools|connectors|integrations|capabilities)\b", re.I),
+    re.compile(
+        r"\bthere(?:'s| is) no (?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear|tool|connector|integration|capability|way)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bthere are no (?:tools|connectors|integrations|capabilities)\b", re.I
+    ),
     # Passive voice
-    re.compile(r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear|that|it) (?:can(?:not| ?'?t)|could(?:not| ?n'?t)) be (?:accessed|reached|queried|searched|opened|connected|used)\b", re.I),
-    re.compile(r"\b(?:is|are) not (?:accessible|reachable|available|supported|connected) (?:from|in|to)\b", re.I),
+    re.compile(
+        r"\b(?:Notion|GitHub|calendar|email|Oracle|Slack|Jira|Linear|that|it) (?:can(?:not| ?'?t)|could(?:not| ?n'?t)) be (?:accessed|reached|queried|searched|opened|connected|used)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:is|are) not (?:accessible|reachable|available|supported|connected) (?:from|in|to)\b",
+        re.I,
+    ),
     # Workspace / context phrasing
-    re.compile(r"\b(?:your |the )?workspace is not (?:connected|accessible|available|configured)\b", re.I),
-    re.compile(r"\b(?:your |the )?(?:account|workspace|integration) (?:isn't|is not) (?:connected|linked|set up|configured)\b", re.I),
+    re.compile(
+        r"\b(?:your |the )?workspace is not (?:connected|accessible|available|configured)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:your |the )?(?:account|workspace|integration) (?:isn't|is not) (?:connected|linked|set up|configured)\b",
+        re.I,
+    ),
     # Hedged / apologetic — "Unfortunately", "I'm afraid"
-    re.compile(r"\b(?:unfortunately|sadly|regrettably)[,\s].{0,80}?(?:not (?:available|accessible|connected|supported|enabled)|isn't (?:available|accessible|connected|supported|enabled))\b", re.I | re.S),
-    re.compile(r"\bI(?:'m| am) (?:afraid|sorry)[,\s].{0,80}?(?:do not|don't|cannot|can't|can ?not)\b", re.I | re.S),
+    re.compile(
+        r"\b(?:unfortunately|sadly|regrettably)[,\s].{0,80}?(?:not (?:available|accessible|connected|supported|enabled)|isn't (?:available|accessible|connected|supported|enabled))\b",
+        re.I | re.S,
+    ),
+    re.compile(
+        r"\bI(?:'m| am) (?:afraid|sorry)[,\s].{0,80}?(?:do not|don't|cannot|can't|can ?not)\b",
+        re.I | re.S,
+    ),
 )
 
 
 _NEGATION_TOKENS: tuple[str, ...] = (
-    "not accessible", "unaccessible", "unavailable", "not available",
-    "not reachable", "unreachable", "not supported", "unsupported",
-    "not connected", "disconnected", "isn't available", "isn't accessible",
-    "isn't connected", "isn't supported", "no access", "without access",
+    "not accessible",
+    "unaccessible",
+    "unavailable",
+    "not available",
+    "not reachable",
+    "unreachable",
+    "not supported",
+    "unsupported",
+    "not connected",
+    "disconnected",
+    "isn't available",
+    "isn't accessible",
+    "isn't connected",
+    "isn't supported",
+    "no access",
+    "without access",
 )
 
 _CAPABILITY_TOKENS: tuple[str, ...] = (
-    "notion", "github", "calendar", "email", "oracle", "slack", "jira",
-    "linear", "gmail", "outlook", "drive", "sharepoint", "confluence",
+    "notion",
+    "github",
+    "calendar",
+    "email",
+    "oracle",
+    "slack",
+    "jira",
+    "linear",
+    "gmail",
+    "outlook",
+    "drive",
+    "sharepoint",
+    "confluence",
 )
 
 # Window for capability-token / negation-token co-occurrence detection.
@@ -119,6 +194,7 @@ def extract_absence_phrases(text: str) -> list[str]:
 def extract_text_from_response_body(body: bytes) -> str:
     """Extract all text block content from a non-streamed Anthropic response body."""
     import json
+
     try:
         data = json.loads(body)
     except (json.JSONDecodeError, ValueError):
@@ -137,6 +213,7 @@ def extract_text_from_response_body(body: bytes) -> str:
 def extract_text_from_sse_buf(buf: bytes) -> str:
     """Extract accumulated text from an SSE byte buffer (content_block_delta events)."""
     import json
+
     try:
         text = buf.decode("utf-8", errors="replace")
     except Exception:

--- a/tcp/proxy/capability_resolution_gate.py
+++ b/tcp/proxy/capability_resolution_gate.py
@@ -44,6 +44,7 @@ _logger = logging.getLogger(__name__)
 #   3. With TCP_CRG_REQUIRE_KEY=1 set, an unset env var raises on import.
 #      Production deployments should set this flag to fail closed on misconfig.
 
+
 def _load_resolver_secret() -> str:
     env_key = os.environ.get("TCP_CRG_RESOLVER_SECRET")
     if env_key:
@@ -108,7 +109,6 @@ def _compute_signature(
         payload.encode(),
         hashlib.sha256,
     ).hexdigest()[:32]
-
 
 
 # ── Semantic capability → MCP server families ──────────────────────────────────

--- a/tcp/proxy/cc_proxy.py
+++ b/tcp/proxy/cc_proxy.py
@@ -33,24 +33,6 @@ from starlette.routing import Route
 from tcp.derivation.request_derivation import SessionStartEvent, derive_request
 from tcp.harness.gating import RuntimeEnvironment, gate_tools
 from tcp.harness.models import ToolSelectionRequest
-from tcp.proxy.controller import (
-    ToolPackController,
-    TPC_RULE_HEURISTIC_UPGRADE,
-    _server_alias_tokens,
-)
-from tcp.proxy.pack_manifest import (
-    DEFAULT_ACTIVE_MCP_SERVERS,
-    PackInspection,
-    PackManifestError,
-    STATE_ACTIVE,
-    STATE_DEFERRED,
-    STATE_SUPPRESSED,
-    default_manifest_path,
-    inspect_pack_state,
-    load_pack_manifest,
-    pack_context_from_env,
-)
-from tcp.proxy.projection import ProjectionTier, project_single_anthropic_tool
 from tcp.proxy.absence_language import (
     contains_absence_language,
     extract_text_from_response_body,
@@ -58,16 +40,34 @@ from tcp.proxy.absence_language import (
 )
 from tcp.proxy.capability_resolution_gate import (
     CapabilityResolution,
-    resolve_capabilities_for_request,
     resolution_to_log_record,
+    resolve_capabilities_for_request,
 )
-from tcp.proxy.survivor_reducer import reduce_survivors
+from tcp.proxy.controller import (
+    TPC_RULE_HEURISTIC_UPGRADE,
+    ToolPackController,
+    _server_alias_tokens,
+)
 from tcp.proxy.denial_enforcement import (
     denial_violation_record,
     enforce_denial_gate,
     may_emit_capability_denial,
 )
+from tcp.proxy.pack_manifest import (
+    DEFAULT_ACTIVE_MCP_SERVERS,
+    STATE_ACTIVE,
+    STATE_DEFERRED,
+    STATE_SUPPRESSED,
+    PackInspection,
+    PackManifestError,
+    default_manifest_path,
+    inspect_pack_state,
+    load_pack_manifest,
+    pack_context_from_env,
+)
+from tcp.proxy.projection import ProjectionTier, project_single_anthropic_tool
 from tcp.proxy.prompt_select import extract_task_prompt
+from tcp.proxy.survivor_reducer import reduce_survivors
 
 PROXY_STATE_DIR = Path.home() / ".tcp-shadow" / "proxy"
 MODE_PATH = PROXY_STATE_DIR / "mode"
@@ -1163,10 +1163,8 @@ def _check_denial_enforcement(
     # Reconstruct lightweight resolution stubs from logged records.
     # Full CapabilityResolution objects are not stored in meta — we use the
     # serialised records to check status, surfaces, and signature.
-    from tcp.proxy.capability_resolution_gate import (
-        SurfaceResult,
-        _REQUIRED_SIX_SURFACES as _SIX,
-    )
+    from tcp.proxy.capability_resolution_gate import _REQUIRED_SIX_SURFACES as _SIX
+    from tcp.proxy.capability_resolution_gate import SurfaceResult
 
     resolutions: list[CapabilityResolution] = []
     for rec in crg_records:

--- a/tcp/proxy/controller.py
+++ b/tcp/proxy/controller.py
@@ -23,13 +23,13 @@ from dataclasses import dataclass
 from typing import Mapping
 
 from tcp.proxy.pack_manifest import (
+    STATE_ACTIVE,
+    STATE_DEFERRED,
+    STATE_SUPPRESSED,
     PackContext,
     PackDecision,
     PackManifest,
     PackState,
-    STATE_ACTIVE,
-    STATE_DEFERRED,
-    STATE_SUPPRESSED,
     resolve_pack_decisions,
 )
 

--- a/tcp/proxy/denial_enforcement.py
+++ b/tcp/proxy/denial_enforcement.py
@@ -39,12 +39,11 @@ from tcp.proxy.absence_language import (
     extract_absence_phrases,
 )
 from tcp.proxy.capability_resolution_gate import (
-    CapabilityResolution,
-    _REQUIRED_SIX_SURFACES,
     _CRG_RESOLVER_SECRET,
+    _REQUIRED_SIX_SURFACES,
+    CapabilityResolution,
     _compute_signature,
 )
-
 
 # ── Rewrite-action mapping ─────────────────────────────────────────────────────
 
@@ -202,9 +201,8 @@ def may_emit_capability_denial(
 
     # Rule 4: unavailable resolution with incomplete surfaces → invalid_resolution.
     for r in resolutions:
-        if (
-            r.status == "unavailable"
-            and set(r.checked_surfaces) != set(_REQUIRED_SIX_SURFACES)
+        if r.status == "unavailable" and set(r.checked_surfaces) != set(
+            _REQUIRED_SIX_SURFACES
         ):
             return DenialGateDecision(
                 allowed=False,

--- a/tcp/proxy/pack_manifest.py
+++ b/tcp/proxy/pack_manifest.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from functools import lru_cache
-import os
 from pathlib import Path
 from typing import Any, Literal, Mapping
 

--- a/tcp/security/human_approval_interface.py
+++ b/tcp/security/human_approval_interface.py
@@ -280,9 +280,7 @@ class HumanApprovalInterface:
             risk_level = request["risk_level"]
 
             risk_emoji = (
-                "🟢"
-                if risk_level == "LOW"
-                else "🟡" if risk_level == "MEDIUM" else "🔴"
+                "🟢" if risk_level == "LOW" else "🟡" if risk_level == "MEDIUM" else "🔴"
             )
 
             print(f"{i}. {tool_name} {risk_emoji} {risk_level} RISK")

--- a/tests/test_precision_regressions.py
+++ b/tests/test_precision_regressions.py
@@ -1,26 +1,38 @@
-
 import pytest
-from tcp.derivation.request_derivation import _derive_capability_flags_from_prompt_only
+
 from tcp.core.descriptors import CapabilityFlags
+from tcp.derivation.request_derivation import _derive_capability_flags_from_prompt_only
+
 
 def test_network_false_positives():
     # "post" in "post-processing" should not trigger SUPPORTS_NETWORK
-    prompt = "analysis on SLM usage for real-time processing: ... web search post-processing"
+    prompt = (
+        "analysis on SLM usage for real-time processing: ... web search post-processing"
+    )
     flags = _derive_capability_flags_from_prompt_only(prompt)
-    assert not (flags & CapabilityFlags.SUPPORTS_NETWORK), f"SUPPORTS_NETWORK triggered by 'post-processing' in: {prompt}"
+    assert not (
+        flags & CapabilityFlags.SUPPORTS_NETWORK
+    ), f"SUPPORTS_NETWORK triggered by 'post-processing' in: {prompt}"
 
     # "request" should not trigger SUPPORTS_NETWORK on its own
     prompt = "I'll make a request to the filesystem"
     flags = _derive_capability_flags_from_prompt_only(prompt)
-    assert not (flags & CapabilityFlags.SUPPORTS_NETWORK), f"SUPPORTS_NETWORK triggered by 'request' in: {prompt}"
+    assert not (
+        flags & CapabilityFlags.SUPPORTS_NETWORK
+    ), f"SUPPORTS_NETWORK triggered by 'request' in: {prompt}"
+
 
 def test_file_false_positives():
     # "e.g." should not trigger SUPPORTS_FILES
     prompt = "any patterns appear (e.g., fast model does quick checks)"
     flags = _derive_capability_flags_from_prompt_only(prompt)
-    assert not (flags & CapabilityFlags.SUPPORTS_FILES), f"SUPPORTS_FILES triggered by 'e.g.' in: {prompt}"
+    assert not (
+        flags & CapabilityFlags.SUPPORTS_FILES
+    ), f"SUPPORTS_FILES triggered by 'e.g.' in: {prompt}"
 
     # "npm" should not trigger SUPPORTS_FILES
     prompt = "March 31 2026 npm sourcemap version"
     flags = _derive_capability_flags_from_prompt_only(prompt)
-    assert not (flags & CapabilityFlags.SUPPORTS_FILES), f"SUPPORTS_FILES triggered by 'npm' in: {prompt}"
+    assert not (
+        flags & CapabilityFlags.SUPPORTS_FILES
+    ), f"SUPPORTS_FILES triggered by 'npm' in: {prompt}"

--- a/tests/test_snf.py
+++ b/tests/test_snf.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from tcp.core.snf import SNFCanonicalizer, SNFError

--- a/tests/unit/derivation/test_request_derivation.py
+++ b/tests/unit/derivation/test_request_derivation.py
@@ -1,15 +1,16 @@
 """Tests for TCP-DS-2 request derivation contract."""
 
 import pytest
+
 from tcp.core.descriptors import CapabilityFlags
-from tcp.harness.models import ToolSelectionRequest
 from tcp.derivation.request_derivation import (
-    derive_request,
-    classify_unscorable,
-    get_equivalence_class,
-    SessionStartEvent,
     PostToolUseEvent,
+    SessionStartEvent,
+    classify_unscorable,
+    derive_request,
+    get_equivalence_class,
 )
+from tcp.harness.models import ToolSelectionRequest
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
 

--- a/tests/unit/test_ambiguous_tasks.py
+++ b/tests/unit/test_ambiguous_tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from tcp.agent.ambiguous_tasks import build_ambiguous_tasks, AmbiguousTask
+from tcp.agent.ambiguous_tasks import AmbiguousTask, build_ambiguous_tasks
 from tcp.harness.gating import RuntimeEnvironment, gate_tools
 from tcp.harness.router import RouteConfidence, route_tool
 

--- a/tests/unit/test_capability_resolution_gate.py
+++ b/tests/unit/test_capability_resolution_gate.py
@@ -15,13 +15,13 @@ from __future__ import annotations
 import pytest
 
 from tcp.proxy.capability_resolution_gate import (
-    CRGContext,
-    CapabilityResolution,
     _REQUIRED_SIX_SURFACES,
+    CapabilityResolution,
+    CRGContext,
     extract_requested_capabilities,
-    resolve_capability,
-    resolve_capabilities_for_request,
     resolution_to_log_record,
+    resolve_capabilities_for_request,
+    resolve_capability,
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/unit/test_cc_proxy_doctor.py
+++ b/tests/unit/test_cc_proxy_doctor.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 

--- a/tests/unit/test_cc_proxy_headers.py
+++ b/tests/unit/test_cc_proxy_headers.py
@@ -21,8 +21,8 @@ from starlette.testclient import TestClient
 from tcp.proxy.cc_proxy import (
     UPSTREAM_LIMITS,
     UPSTREAM_TIMEOUT,
-    _build_upstream_client,
     _buffered_response_headers,
+    _build_upstream_client,
     _forward_headers,
     _streaming_response_headers,
     _write_decision_record,

--- a/tests/unit/test_cc_proxy_response_tap.py
+++ b/tests/unit/test_cc_proxy_response_tap.py
@@ -19,10 +19,10 @@ import time
 from pathlib import Path
 
 from tcp.proxy.cc_proxy import (
-    _ExpectedToolDerivation,
     _all_tools_from_response_body,
     _all_tools_from_sse_buf,
     _compute_expected_tool_name,
+    _ExpectedToolDerivation,
     _first_tool_from_response_body,
     _first_tool_from_sse_buf,
     _top_survivor_by_prompt_similarity,
@@ -347,7 +347,10 @@ class TestComputeExpectedToolName:
         assert d.candidate_set_size == 2
 
     def test_three_survivors_abstains(self):
-        meta = {"survivor_count": 3, "survivor_names_sorted": ["alpha", "beta", "gamma"]}
+        meta = {
+            "survivor_count": 3,
+            "survivor_names_sorted": ["alpha", "beta", "gamma"],
+        }
         d = _compute_expected_tool_name(meta)
         assert d.expected_tool_name is None
         assert d.abstain_reason == "ambiguous_3_survivors"
@@ -691,8 +694,8 @@ class TestDenialEnforcementIntegration:
 
         from tcp.proxy.capability_resolution_gate import (
             CRGContext,
-            resolve_capability,
             resolution_to_log_record,
+            resolve_capability,
         )
 
         _NOTION_TOOL = "mcp__notion-agents__query_database"
@@ -846,7 +849,11 @@ class TestDenialEnforcementIntegration:
         log = tmp_path / "decisions.jsonl"
         monkeypatch.setattr("tcp.proxy.cc_proxy.DECISIONS_LOG", log)
 
-        meta: dict = {"survivor_count": 1, "survivor_names_sorted": ["Bash"], "crg_resolutions": []}
+        meta: dict = {
+            "survivor_count": 1,
+            "survivor_names_sorted": ["Bash"],
+            "crg_resolutions": [],
+        }
         _check_denial_enforcement("", meta)
         _write_decision_record(time.time(), meta, "Bash")
 

--- a/tests/unit/test_cc_proxy_runtime.py
+++ b/tests/unit/test_cc_proxy_runtime.py
@@ -13,10 +13,16 @@ from tcp.proxy.cc_proxy import _runtime_from_env
 def test_cc_proxy_module_imports_cleanly() -> None:
     """cc_proxy must import without error; catches missing names in the import block."""
     import importlib
+
     import tcp.proxy.cc_proxy as mod
+
     assert mod is not None
     # Spot-check symbols that have historically broken the import.
-    assert callable(mod.may_emit_capability_denial if hasattr(mod, "may_emit_capability_denial") else mod._check_denial_enforcement)
+    assert callable(
+        mod.may_emit_capability_denial
+        if hasattr(mod, "may_emit_capability_denial")
+        else mod._check_denial_enforcement
+    )
     assert callable(mod._compute_expected_tool_name)
     assert callable(mod._write_decision_record)
 

--- a/tests/unit/test_conservative_live_filtering.py
+++ b/tests/unit/test_conservative_live_filtering.py
@@ -15,15 +15,16 @@ import os
 from typing import Any
 
 import pytest
+
 from tcp.core.descriptors import CapabilityFlags
 from tcp.derivation.request_derivation import SessionStartEvent, derive_request
 from tcp.harness.gating import RuntimeEnvironment, gate_tools
 from tcp.harness.models import ToolRecord, ToolSelectionRequest
 from tcp.proxy.cc_proxy import (
-    _process_tools_array,
-    _SAFETY_FLOOR_TOOLS,
     _DEFAULT_ALLOWED_MCP_SERVERS,
+    _SAFETY_FLOOR_TOOLS,
     _is_mcp_server_allowed,
+    _process_tools_array,
 )
 from tcp.proxy.projection import ProjectionTier, project_single_anthropic_tool
 

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -17,12 +17,12 @@ from tcp.proxy.controller import (
     ToolPackController,
 )
 from tcp.proxy.pack_manifest import (
-    PackContext,
-    PackManifest,
-    PackRule,
     STATE_ACTIVE,
     STATE_DEFERRED,
     STATE_SUPPRESSED,
+    PackContext,
+    PackManifest,
+    PackRule,
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/unit/test_crg_guarantee_adversarial.py
+++ b/tests/unit/test_crg_guarantee_adversarial.py
@@ -37,11 +37,11 @@ import pytest
 
 from tcp.proxy.absence_language import contains_absence_language
 from tcp.proxy.capability_resolution_gate import (
-    CRGContext,
-    CapabilityResolution,
-    SurfaceResult,
     _CRG_RESOLVER_SECRET,
     _REQUIRED_SIX_SURFACES,
+    CapabilityResolution,
+    CRGContext,
+    SurfaceResult,
     _compute_signature,
     resolve_capability,
 )
@@ -56,6 +56,7 @@ _NOTION_TOOL = "mcp__notion-agents__query_database"
 _KNOWN_LITERAL_KEY = "crg-resolver-default-v1"  # the historical default
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
+
 
 def _available_ctx() -> CRGContext:
     return CRGContext(
@@ -81,13 +82,16 @@ def _unavailable_ctx() -> CRGContext:
 
 def _make_available_resolution() -> CapabilityResolution:
     r = resolve_capability("notion.search", _available_ctx())
-    assert r.status in ("callable_now", "schema_deferred"), (
-        f"pre-condition: expected available resolution, got {r.status}"
-    )
+    assert r.status in (
+        "callable_now",
+        "schema_deferred",
+    ), f"pre-condition: expected available resolution, got {r.status}"
     return r
 
 
-def _forge_with_known_literal(capability: str = "notion.search") -> CapabilityResolution:
+def _forge_with_known_literal(
+    capability: str = "notion.search",
+) -> CapabilityResolution:
     """Forge an unavailable resolution using the historical literal key.
 
     With the fix, this should NOT validate, because the resolver no longer
@@ -97,13 +101,20 @@ def _forge_with_known_literal(capability: str = "notion.search") -> CapabilityRe
     status = "unavailable"
     matched_tools: tuple[str, ...] = ()
     surface_results = tuple(
-        SurfaceResult(surface=s, matched=False, tools=(), timestamp="", reason="", stale=False)
+        SurfaceResult(
+            surface=s, matched=False, tools=(), timestamp="", reason="", stale=False
+        )
         for s in _REQUIRED_SIX_SURFACES
     )
 
     canonical_surfaces = sorted(
         (
-            {"surface": sr.surface, "matched": sr.matched, "tools": sorted(sr.tools), "stale": sr.stale}
+            {
+                "surface": sr.surface,
+                "matched": sr.matched,
+                "tools": sorted(sr.tools),
+                "stale": sr.stale,
+            }
             for sr in surface_results
         ),
         key=lambda d: d["surface"],
@@ -140,8 +151,8 @@ def _forge_with_known_literal(capability: str = "notion.search") -> CapabilityRe
 
 # ── Nominal guarantee ─────────────────────────────────────────────────────────
 
-class TestNominalGuaranteeHolds:
 
+class TestNominalGuaranteeHolds:
     def test_p1_true_p2_true_produces_violation(self):
         resolution = _make_available_resolution()
         decision = enforce_denial_gate("I don't have access to Notion.", [resolution])
@@ -180,6 +191,7 @@ class TestNominalGuaranteeHolds:
 
 # ── Stream-abort breach: REMEDIATED ───────────────────────────────────────────
 
+
 class TestStreamAbortRemediated:
     """Regression guard: the finally block must call _check_denial_enforcement."""
 
@@ -189,7 +201,9 @@ class TestStreamAbortRemediated:
         import ast
         from pathlib import Path
 
-        proxy_path = Path(__file__).parent.parent.parent / "tcp" / "proxy" / "cc_proxy.py"
+        proxy_path = (
+            Path(__file__).parent.parent.parent / "tcp" / "proxy" / "cc_proxy.py"
+        )
         tree = ast.parse(proxy_path.read_text())
 
         denial_check_in_any_finally = False
@@ -232,6 +246,7 @@ class TestStreamAbortRemediated:
 
 # ── Pattern evasion: REMEDIATED ───────────────────────────────────────────────
 
+
 class TestPatternEvasionRemediated:
     """Regression guard: the 14 documented evasion phrases must all be detected."""
 
@@ -254,9 +269,9 @@ class TestPatternEvasionRemediated:
 
     @pytest.mark.parametrize("phrase", _PREVIOUSLY_EVADING_PHRASES)
     def test_previously_evading_phrase_now_detected(self, phrase: str):
-        assert contains_absence_language(phrase), (
-            f"REGRESSION: '{phrase}' is no longer detected as absence language."
-        )
+        assert contains_absence_language(
+            phrase
+        ), f"REGRESSION: '{phrase}' is no longer detected as absence language."
 
     def test_evasion_phrase_now_blocks_unjustified_denial(self):
         resolution = _make_available_resolution()
@@ -280,12 +295,13 @@ class TestPatternEvasionRemediated:
             "The Notion integration is enabled and working.",
         ]
         for text in clean_phrases:
-            assert not contains_absence_language(text), (
-                f"FALSE POSITIVE: '{text}' is being flagged as absence language."
-            )
+            assert not contains_absence_language(
+                text
+            ), f"FALSE POSITIVE: '{text}' is being flagged as absence language."
 
 
 # ── HMAC key in source: REMEDIATED ────────────────────────────────────────────
+
 
 class TestHMACKeyInSourceRemediated:
     """Regression guard: forging with the historical literal key must fail."""
@@ -302,16 +318,16 @@ class TestHMACKeyInSourceRemediated:
 
     def test_forgery_with_known_literal_key_fails_signature_check(self):
         forged = _forge_with_known_literal("notion.search")
-        assert not _resolution_signature_valid(forged), (
-            "REGRESSION: forgery using the historical literal key validates."
-        )
+        assert not _resolution_signature_valid(
+            forged
+        ), "REGRESSION: forgery using the historical literal key validates."
 
     def test_forgery_with_known_literal_key_does_not_authorise_denial(self):
         forged = _forge_with_known_literal("notion.search")
         decision = enforce_denial_gate("I don't have access to Notion.", [forged])
-        assert decision.allowed is False, (
-            "REGRESSION: forged unavailable resolution silenced the denial gate."
-        )
+        assert (
+            decision.allowed is False
+        ), "REGRESSION: forged unavailable resolution silenced the denial gate."
         assert decision.violation_kind == "denial_violation"
 
     def test_genuine_unavailable_still_authorises_denial(self):
@@ -339,6 +355,7 @@ class TestHMACKeyInSourceRemediated:
 
 # ── Signature scope: REMEDIATED ───────────────────────────────────────────────
 
+
 class TestSignatureScopeRemediated:
     """Regression guard: checked_surfaces and surface_results are now signed."""
 
@@ -354,9 +371,9 @@ class TestSignatureScopeRemediated:
         r = resolve_capability("notion.search", ctx)
         assert _resolution_signature_valid(r)
         stripped = replace(r, checked_surfaces=())
-        assert not _resolution_signature_valid(stripped), (
-            "REGRESSION: checked_surfaces is no longer covered by the HMAC."
-        )
+        assert not _resolution_signature_valid(
+            stripped
+        ), "REGRESSION: checked_surfaces is no longer covered by the HMAC."
 
     def test_mutating_surface_results_invalidates_signature(self):
         r = resolve_capability("notion.search", _unavailable_ctx())
@@ -371,9 +388,9 @@ class TestSignatureScopeRemediated:
         )
         new_surfaces = (forged_surface,) + r.surface_results[1:]
         tampered = replace(r, surface_results=new_surfaces)
-        assert not _resolution_signature_valid(tampered), (
-            "REGRESSION: surface_results is no longer covered by the HMAC."
-        )
+        assert not _resolution_signature_valid(
+            tampered
+        ), "REGRESSION: surface_results is no longer covered by the HMAC."
 
     def test_resolver_signed_resolutions_remain_valid(self):
         """Control: legitimate resolutions still pass the wider signature check."""
@@ -383,6 +400,7 @@ class TestSignatureScopeRemediated:
 
 
 # ── End-to-end: forged + evasion combo ────────────────────────────────────────
+
 
 class TestEndToEndDefenseInDepth:
     """Each fix is independent; verify no single fix relies on another."""

--- a/tests/unit/test_denial_enforcement.py
+++ b/tests/unit/test_denial_enforcement.py
@@ -21,10 +21,10 @@ from tcp.proxy.absence_language import (
     extract_text_from_sse_buf,
 )
 from tcp.proxy.capability_resolution_gate import (
-    CRGContext,
-    resolve_capability,
-    _compute_signature,
     _REQUIRED_SIX_SURFACES,
+    CRGContext,
+    _compute_signature,
+    resolve_capability,
 )
 from tcp.proxy.denial_enforcement import (
     DenialGateDecision,
@@ -57,9 +57,11 @@ def _make_resolution(
     r = resolve_capability(capability, ctx)
     if tamper_status:
         from dataclasses import replace
+
         r = replace(r, status=tamper_status)
     if not sign:
         from dataclasses import replace
+
         r = replace(r, signature="")
     return r
 
@@ -77,14 +79,15 @@ def _make_unavailable_resolution(sign: bool = True):
     assert r.status == "unavailable"
     if not sign:
         from dataclasses import replace
+
         r = replace(r, signature="")
     return r
 
 
 # ── Absence language detection ────────────────────────────────────────────────
 
-class TestAbsenceLanguageDetection:
 
+class TestAbsenceLanguageDetection:
     def test_no_notion_phrase_clean(self):
         assert not contains_absence_language("I can search Notion for you.")
 
@@ -117,23 +120,27 @@ class TestAbsenceLanguageDetection:
 
 # ── extract_text_from_response_body ──────────────────────────────────────────
 
-class TestExtractTextFromResponseBody:
 
+class TestExtractTextFromResponseBody:
     def test_extracts_text_block(self):
         import json
-        body = json.dumps({
-            "content": [
-                {"type": "text", "text": "I don't have access to Notion."},
-                {"type": "tool_use", "name": "some_tool"},
-            ]
-        }).encode()
+
+        body = json.dumps(
+            {
+                "content": [
+                    {"type": "text", "text": "I don't have access to Notion."},
+                    {"type": "tool_use", "name": "some_tool"},
+                ]
+            }
+        ).encode()
         assert "don't have access" in extract_text_from_response_body(body)
 
     def test_empty_on_tool_only_response(self):
         import json
-        body = json.dumps({
-            "content": [{"type": "tool_use", "name": "some_tool"}]
-        }).encode()
+
+        body = json.dumps(
+            {"content": [{"type": "tool_use", "name": "some_tool"}]}
+        ).encode()
         assert extract_text_from_response_body(body) == ""
 
     def test_empty_on_malformed_body(self):
@@ -142,25 +149,34 @@ class TestExtractTextFromResponseBody:
 
 # ── extract_text_from_sse_buf ─────────────────────────────────────────────────
 
-class TestExtractTextFromSSEBuf:
 
+class TestExtractTextFromSSEBuf:
     def test_extracts_text_deltas(self):
         import json
+
         events = [
-            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "I don't "}},
-            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "have access."}},
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "I don't "},
+            },
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "have access."},
+            },
         ]
-        buf = b"".join(
-            f"data: {json.dumps(e)}\n\n".encode() for e in events
-        )
+        buf = b"".join(f"data: {json.dumps(e)}\n\n".encode() for e in events)
         text = extract_text_from_sse_buf(buf)
         assert "don't" in text
         assert "have access" in text
 
     def test_ignores_tool_events(self):
         import json
+
         events = [
-            {"type": "content_block_start", "content_block": {"type": "tool_use", "name": "foo"}},
+            {
+                "type": "content_block_start",
+                "content_block": {"type": "tool_use", "name": "foo"},
+            },
         ]
         buf = b"".join(f"data: {json.dumps(e)}\n\n".encode() for e in events)
         assert extract_text_from_sse_buf(buf) == ""
@@ -168,8 +184,8 @@ class TestExtractTextFromSSEBuf:
 
 # ── enforce_denial_gate ───────────────────────────────────────────────────────
 
-class TestEnforceDenialGate:
 
+class TestEnforceDenialGate:
     def test_no_absence_language_is_allowed(self):
         decision = enforce_denial_gate(
             "Here are your Notion search results.",
@@ -228,17 +244,20 @@ class TestEnforceDenialGate:
 
     def test_violation_record_is_json_serializable(self):
         import json
+
         resolution = _make_resolution(status="schema_deferred")
         decision = enforce_denial_gate("I don't have access to Notion.", [resolution])
-        record = denial_violation_record(decision, "I don't have access to Notion.", "notion.search")
+        record = denial_violation_record(
+            decision, "I don't have access to Notion.", "notion.search"
+        )
         assert record["kind"] == "denial_violation"
         json.dumps(record)
 
 
 # ── Signature verification ────────────────────────────────────────────────────
 
-class TestSignatureVerification:
 
+class TestSignatureVerification:
     def test_resolver_computed_signature_is_valid(self):
         ctx = CRGContext(
             visible_tools=frozenset({_NOTION_TOOL}),
@@ -254,6 +273,7 @@ class TestSignatureVerification:
 
     def test_tampered_status_invalidates_signature(self):
         from dataclasses import replace
+
         ctx = CRGContext(
             visible_tools=frozenset({_NOTION_TOOL}),
             deferred_tools=frozenset(),
@@ -268,6 +288,7 @@ class TestSignatureVerification:
 
     def test_tampered_matched_tools_invalidates_signature(self):
         from dataclasses import replace
+
         ctx = CRGContext(
             visible_tools=frozenset({_NOTION_TOOL}),
             deferred_tools=frozenset(),
@@ -282,6 +303,7 @@ class TestSignatureVerification:
 
     def test_empty_signature_is_invalid(self):
         from dataclasses import replace
+
         ctx = CRGContext(
             visible_tools=frozenset({_NOTION_TOOL}),
             deferred_tools=frozenset(),
@@ -297,6 +319,7 @@ class TestSignatureVerification:
     def test_tampered_unavailable_blocks_denial(self):
         """Core tamper test: mutate status on a signed resolution, gate rejects."""
         from dataclasses import replace
+
         ctx = CRGContext(
             visible_tools=frozenset({_NOTION_TOOL}),
             deferred_tools=frozenset(),
@@ -437,7 +460,9 @@ class TestMayEmitCapabilityDenial:
 
     def test_case_insensitive_cannot(self):
         """10. "cannot" triggers absence-language detection."""
-        assert may_emit_capability_denial("I cannot access Notion.", []).allowed is False
+        assert (
+            may_emit_capability_denial("I cannot access Notion.", []).allowed is False
+        )
 
     def test_case_insensitive_dont(self):
         """10. "don't" triggers absence-language detection."""

--- a/tests/unit/test_per_task_filtering.py
+++ b/tests/unit/test_per_task_filtering.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from tcp.agent.benchmark import (
-    build_filtered_schemas,
-    build_fixed_filtered_schemas,
-)
+from tcp.agent.benchmark import build_filtered_schemas, build_fixed_filtered_schemas
 from tcp.agent.tasks import AgentTask, build_agent_tasks
 from tcp.harness.corpus import build_mcp_corpus
 from tcp.harness.schema_bridge import corpus_to_anthropic_schemas

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from tcp.harness.router import RouteConfidence, RouteResult, route_tool
 from tcp.harness.gating import RuntimeEnvironment
 from tcp.harness.models import ToolRecord, ToolSelectionRequest
+from tcp.harness.router import RouteConfidence, RouteResult, route_tool
 
 
 def _make_record(name: str, commands: frozenset[str] = frozenset()) -> ToolRecord:

--- a/tests/unit/test_shadow_freshness.py
+++ b/tests/unit/test_shadow_freshness.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import json
 
 from scripts.shadow_analysis import (
-    analyse_session,
     _decision_has_freshness_context,
     _load_decision_index,
     _match_decision_record,
     _prompt_hash,
+    analyse_session,
 )
 from tcp.proxy.tool_flag_map import build_static_inventory
 


### PR DESCRIPTION
Fixes the scheduled TCP Quality Assurance Pipeline failure from run 25902533911.

Changes are intentionally mechanical:
- applied Black formatting to the CI Black targets (`tcp`, `tests`, `scripts`)
- applied isort to the CI isort targets (`tcp`, `tests`)
- renamed one ambiguous local variable in `tcp/core/signing_surface.py` so the next flake8 gate passes

Local verification:
- `uvx --from 'black==23.12.1' black --check --diff tcp tests scripts`
- `uvx --from 'isort==5.12.0' isort --check-only --diff tcp tests`
- `uvx --from 'flake8==6.1.0' flake8 tcp tests`
- `python3 -m compileall -q tcp tests scripts`