### PR TITLE
ci: skip absent optional validation suites

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -284,12 +284,25 @@ jobs:
       run: poetry install --with dev,test
       
     - name: External Validation Tests
+      id: external-validation-tests
       run: |
-        poetry run pytest tests/external_validation/ \
-          --junitxml=pytest-external.xml \
-          -v
+        external_test_files=$(find tests/external_validation -type f \( -name 'test_*.py' -o -name '*_test.py' \) 2>/dev/null | tr '\n' ' ')
+        if [ -n "$external_test_files" ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          poetry run pytest $external_test_files \
+            --junitxml=pytest-external.xml \
+            -v
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          cat > pytest-external.xml <<'EOF'
+        <?xml version="1.0" encoding="utf-8"?>
+        <testsuite name="external-validation" tests="0" skipped="0" failures="0" errors="0" time="0" />
+        EOF
+          echo "No tests/external_validation directory; skipping optional external validation tests."
+        fi
           
     - name: Generate Audit Evidence Package
+      if: steps.external-validation-tests.outputs.present == 'true'
       run: |
         poetry run python consortium/alex-rivera/external-validation/TCP_REPRODUCTION_HARNESS.py \
           --output-dir=audit-evidence \
@@ -297,6 +310,7 @@ jobs:
           --include-hardware-specs
           
     - name: Trail of Bits Preparation
+      if: steps.external-validation-tests.outputs.present == 'true'
       run: |
         mkdir -p trail-of-bits-package
         cp -r audit-evidence/* trail-of-bits-package/
@@ -304,12 +318,15 @@ jobs:
         cp consortium/alex-rivera/external-validation/TCP_SECURITY_CLAIMS_EVIDENCE.md trail-of-bits-package/
         
     - name: Academic Partnership Package
+      if: steps.external-validation-tests.outputs.present == 'true'
       run: |
         mkdir -p academic-package
+        mkdir -p academic-package/test-data
         cp -r audit-evidence/* academic-package/
         cp tests/fixtures/* academic-package/test-data/
         
     - name: Upload External Validation Packages
+      if: steps.external-validation-tests.outputs.present == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: external-validation-packages
@@ -341,14 +358,26 @@ jobs:
       run: poetry install --with dev,test
       
     - name: Reliability Tests
+      id: reliability-tests
       timeout-minutes: 120
       run: |
-        poetry run pytest tests/reliability/ \
-          --junitxml=pytest-reliability.xml \
-          --timeout=7200 \
-          -v -s
+        reliability_test_files=$(find tests/reliability -type f \( -name 'test_*.py' -o -name '*_test.py' \) 2>/dev/null | tr '\n' ' ')
+        if [ -n "$reliability_test_files" ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          poetry run pytest $reliability_test_files \
+            --junitxml=pytest-reliability.xml \
+            -v -s
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          cat > pytest-reliability.xml <<'EOF'
+        <?xml version="1.0" encoding="utf-8"?>
+        <testsuite name="reliability" tests="0" skipped="0" failures="0" errors="0" time="0" />
+        EOF
+          echo "No tests/reliability directory; skipping optional reliability tests."
+        fi
           
     - name: Chaos Engineering Tests
+      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/chaos_engineering.py') != ''
       run: |
         poetry run python tests/reliability/chaos_engineering.py \
           --duration=3600 \
@@ -356,6 +385,7 @@ jobs:
           --output=chaos-results.json
           
     - name: Load Testing
+      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/load_testing.py') != ''
       run: |
         poetry run python tests/reliability/load_testing.py \
           --concurrent-users=10000 \
@@ -363,6 +393,7 @@ jobs:
           --output=load-results.json
           
     - name: Reliability Report Generation
+      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/generate_report.py') != ''
       run: |
         poetry run python tests/reliability/generate_report.py \
           --input-dir=. \
@@ -370,10 +401,13 @@ jobs:
           --target=99.999
           
     - name: Upload Reliability Results
+      if: always() && steps.reliability-tests.outputs.present == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: reliability-results
+        if-no-files-found: ignore
         path: |
+          pytest-reliability.xml
           chaos-results.json
           load-results.json
           reliability-report.html


### PR DESCRIPTION
## Summary\n- skip optional external validation when no pytest-discoverable suite exists\n- skip optional reliability tests when no pytest-discoverable suite exists\n- remove the unsupported pytest --timeout argument from reliability testing\n- gate optional package/report steps on the files they require\n\n## Verification\n- parsed .github/workflows/quality.yml with PyYAML\n- checked every workflow run block with bash -n\n- git diff --check\n\nFixes workflow run https://github.com/git-scarrow/tool-capability-protocol/actions/runs/25983642530