### PR TITLE
ci: update download artifact action

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -465,7 +465,7 @@ jobs:
     
     steps:
     - name: Download All Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       
     - name: Generate Deployment Report
       run: |


### PR DESCRIPTION
Fixes the remaining TCP Quality Assurance Pipeline failure from run 25984707674.

GitHub now hard-fails actions/download-artifact@v3. The deployment readiness job was still using v3 while uploads had already moved to v4. This updates the download step to actions/download-artifact@v4.

Validation: workflow-only change; inspected the failed run logs and verified the patch is limited to .github/workflows/quality.yml.