### PR TITLE
ci: decouple reliability scripts from pytest discovery

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -401,7 +401,7 @@ jobs:
           --target=99.999
           
     - name: Upload Reliability Results
-      if: always() && (steps.reliability-tests.outputs.present == 'true' || hashFiles('tests/reliability/chaos_engineering.py') != '' || hashFiles('tests/reliability/load_testing.py') != '' || hashFiles('tests/reliability/generate_report.py') != '')
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: reliability-results


### PR DESCRIPTION
Follow-up to PR #88 and Codex P2 review feedback.

The reliability helper scripts are optional standalone validations. They should be gated by their own file existence checks, not by whether pytest-discoverable reliability tests are present.

Changes:
- Run chaos_engineering.py, load_testing.py, and generate_report.py whenever each script exists.
- Always run the reliability artifact upload step with if-no-files-found: ignore, so generated standalone outputs are not skipped when pytest tests are absent.

Validation:
- Parsed .github/workflows/quality.yml with Python YAML parser successfully.