### PR TITLE
ci: decouple reliability script gates from pytest discovery

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -373,11 +373,11 @@ jobs:
         <?xml version="1.0" encoding="utf-8"?>
         <testsuite name="reliability" tests="0" skipped="0" failures="0" errors="0" time="0" />
         EOF
-          echo "No tests/reliability directory; skipping optional reliability tests."
+          echo "No pytest-discoverable reliability tests; skipping optional pytest reliability tests."
         fi
           
     - name: Chaos Engineering Tests
-      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/chaos_engineering.py') != ''
+      if: hashFiles('tests/reliability/chaos_engineering.py') != ''
       run: |
         poetry run python tests/reliability/chaos_engineering.py \
           --duration=3600 \
@@ -385,7 +385,7 @@ jobs:
           --output=chaos-results.json
           
     - name: Load Testing
-      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/load_testing.py') != ''
+      if: hashFiles('tests/reliability/load_testing.py') != ''
       run: |
         poetry run python tests/reliability/load_testing.py \
           --concurrent-users=10000 \
@@ -393,7 +393,7 @@ jobs:
           --output=load-results.json
           
     - name: Reliability Report Generation
-      if: steps.reliability-tests.outputs.present == 'true' && hashFiles('tests/reliability/generate_report.py') != ''
+      if: hashFiles('tests/reliability/generate_report.py') != ''
       run: |
         poetry run python tests/reliability/generate_report.py \
           --input-dir=. \
@@ -401,7 +401,7 @@ jobs:
           --target=99.999
           
     - name: Upload Reliability Results
-      if: always() && steps.reliability-tests.outputs.present == 'true'
+      if: always() && (steps.reliability-tests.outputs.present == 'true' || hashFiles('tests/reliability/chaos_engineering.py') != '' || hashFiles('tests/reliability/load_testing.py') != '' || hashFiles('tests/reliability/generate_report.py') != '')
       uses: actions/upload-artifact@v4
       with:
         name: reliability-results


### PR DESCRIPTION
## Summary
- run standalone reliability scripts whenever their files exist, even if no pytest-discoverable reliability tests are present
- upload reliability artifacts when either pytest reliability tests or standalone reliability scripts are present
- clarify the optional pytest reliability skip message

## Verification
- parsed .github/workflows/quality.yml with PyYAML
- checked every workflow run block with bash -n
- git diff --check HEAD~1..HEAD

Follow-up for review comment on #88: https://github.com/git-scarrow/tool-capability-protocol/pull/88#discussion_r3254210766